### PR TITLE
[v0x01] FIX #24 - Error with MetaClass and __ordered__

### DIFF
--- a/pyof/v0x01/foundation/base.py
+++ b/pyof/v0x01/foundation/base.py
@@ -87,7 +87,7 @@ class GenericType(object):
             self._value = struct.unpack_from(self._fmt, buff, offset)[0]
         except struct.error:
             raise exceptions.Exception("Error while unpacking"
-                                          "data from buffer")
+                                       "data from buffer")
 
     def get_size(self):
         """ Return the size of type in bytes. """
@@ -102,8 +102,11 @@ class MetaStruct(type):
         return collections.OrderedDict()
 
     def __new__(self, name, bases, classdict):
-        classdict['__ordered__'] = [(key, type(value)) for key, value in
-                                    classdict.items() if key[0] != '_']
+        classdict['__ordered__'] = [(key, type(value))
+                                    for key, value in
+                                    classdict.items()
+                                    if key[0] != '_' and not
+                                    hasattr(value, '__call__')]
         return type.__new__(self, name, bases, classdict)
 
 


### PR DESCRIPTION
Error with MetaClass and __ordered__ while dealing with rewritten methods.

Now we check if an attribute is not a function before adding it to the
__ordered__ class attribute.