### PR TITLE
[v0x01] Fix #13 - 'Special Lists'

### DIFF
--- a/pyof/v0x01/asynchronous/error_msg.py
+++ b/pyof/v0x01/asynchronous/error_msg.py
@@ -9,6 +9,7 @@ import enum
 from pyof.v0x01.common import header as of_header
 from pyof.v0x01.foundation import base
 from pyof.v0x01.foundation import basic_types
+from pyof.v0x01.foundation import exceptions
 
 # Enums
 
@@ -155,11 +156,17 @@ class ErrorMsg(base.GenericStruct):
     header = of_header.Header()
     error_type = basic_types.UBInt16()
     code = basic_types.UBInt16()
-    data = []  # TODO: add special basictype
+    data = basic_types.ConstantTypeList()
 
-    def __init__(self, xid=None, error_type=None, code=None, data=None):
+    def __init__(self, xid=None, error_type=None, code=None, data=[]):
         self.header.message_type = of_header.Type.OFPT_ERROR
         self.header.xid = xid
         self.error_type = error_type
         self.code = code
         self.data = data
+
+    def unpack(self, buff, offset=0):
+        # TODO: Implement the unpack method evaluation the error_type and code
+        #       to unpack the data attribute
+        raise exceptions.MethodNotImplemented("'Unpack' method not implemented"
+                                              "on ErrorMsg class.")

--- a/pyof/v0x01/asynchronous/packet_in.py
+++ b/pyof/v0x01/asynchronous/packet_in.py
@@ -30,8 +30,7 @@ class PacketInReason(enum.Enum):
 
 
 class PacketIn(base.GenericMessage):
-    """
-    Packet received on port (datapath -> controller)
+    """Packet received on port (datapath -> controller)
 
         :param xid:       Openflow xid of the Header
         :param buffer_id: ID assigned by datapath

--- a/pyof/v0x01/common/queue.py
+++ b/pyof/v0x01/common/queue.py
@@ -27,9 +27,23 @@ class QueueProperties(enum.Enum):
 # Classes
 
 
-class QueuePropHeader(base.GenericMessage):
+class ListOfProperties(basic_types.FixedTypeList):
+    """List of properties.
+
+    Represented by instances of QueuePropHeader and
+    used on PacketQueue objects
+
+    Attributes:
+        items (optional): Instance or a list of instances of QueuePropHeader
     """
-    This class describes the header of each queue property.
+    def __init__(self, items=[]):
+        basic_types.FixedTypeList.__init__(self,
+                                           pyof_class=QueuePropHeader,
+                                           items=items)
+
+
+class QueuePropHeader(base.GenericMessage):
+    """This class describes the header of each queue property.
 
         :param property: One of OFPQT_.
         :param len:      Length of property, including this header.
@@ -56,11 +70,9 @@ class PacketQueue(base.GenericMessage):
     queue_id = basic_types.UBInt32()
     length = basic_types.UBInt16()
     pad = basic_types.PAD(2)
-    properties = []
-    # TODO: Add here a new type, list of QueuePropHeader()
-    #       objects. Related to ISSUE #3
+    properties = ListOfProperties()
 
-    def __init__(self, queue_id=None, length=None, properties=None):
+    def __init__(self, queue_id=None, length=None, properties=[]):
         self.queue_id = queue_id
         self.length = length
         self.properties = properties

--- a/pyof/v0x01/controller2switch/common.py
+++ b/pyof/v0x01/controller2switch/common.py
@@ -7,6 +7,7 @@ import enum
 
 # Local source tree imports
 from pyof.v0x01.common import header as of_header
+from pyof.v0x01.common import action
 from pyof.v0x01.foundation import base
 from pyof.v0x01.foundation import basic_types
 
@@ -50,3 +51,18 @@ class SwitchConfig(base.GenericMessage):
         self.header.xid = xid
         self.flags = flags
         self.miss_send_len = miss_send_len
+
+
+class ListOfActions(basic_types.FixedTypeList):
+    """List of actions.
+
+    Represented by instances of ActionHeader and
+    used on ActionHeader objects
+
+    Attributes:
+        items (optional): Instance or a list of instances of ActionHeader
+    """
+    def __init__(self, items=[]):
+        basic_types.FixedTypeList.__init__(self,
+                                           pyof_class=action.ActionHeader,
+                                           items=items)

--- a/pyof/v0x01/controller2switch/features_reply.py
+++ b/pyof/v0x01/controller2switch/features_reply.py
@@ -7,6 +7,7 @@ import enum
 
 # Local source tree imports
 from pyof.v0x01.common import header as of_header
+from pyof.v0x01.common import phy_port
 from pyof.v0x01.foundation import base
 from pyof.v0x01.foundation import basic_types
 
@@ -39,6 +40,20 @@ class Capabilities(enum.Enum):
 
 # Classes
 
+class ListOfPhyPorts(basic_types.FixedTypeList):
+    """List of PhyPorts.
+
+    Represented by instances of PhyPort and
+    used on FeaturesReply/SwitchFeatures objects
+
+    Attributes:
+        items (optional): Instance or a list of instances of PhyPort
+    """
+    def __init__(self, items=[]):
+        basic_types.FixedTypeList.__init__(self,
+                                           pyof_class=phy_port.PhyPort,
+                                           items=items)
+
 
 class SwitchFeatures(base.GenericMessage):
     """Message sent by the switch device to the controller.
@@ -67,13 +82,11 @@ class SwitchFeatures(base.GenericMessage):
     # Features
     capabilities = basic_types.UBInt32()
     actions = basic_types.UBInt32()
-    ports = []
-    # TODO: Add here a new type, list of phyPort()
-    # objects. Related to ISSUE #3
+    ports = ListOfPhyPorts()
 
     def __init__(self, xid=None, datapath_id=None, n_buffers=None,
                  n_tables=None, capabilities=None, actions=None,
-                 ports=None):
+                 ports=[]):
 
         self.header.message_type = of_header.Type.OFPT_FEATURES_REPLY
         self.header.length = 40
@@ -84,6 +97,7 @@ class SwitchFeatures(base.GenericMessage):
         self.capabilities = capabilities
         self.actions = actions
         self.ports = ports
+
 
 class FeaturesReply(SwitchFeatures):
     pass

--- a/pyof/v0x01/controller2switch/flow_mod.py
+++ b/pyof/v0x01/controller2switch/flow_mod.py
@@ -8,6 +8,7 @@ import enum
 # Local source tree imports
 from pyof.v0x01.common import flow_match
 from pyof.v0x01.common import header as of_header
+from pyof.v0x01.controller2switch import common
 from pyof.v0x01.foundation import base
 from pyof.v0x01.foundation import basic_types
 
@@ -80,13 +81,11 @@ class FlowMod(base.GenericMessage):
     buffer_id = basic_types.UBInt32()
     out_port = basic_types.UBInt16()
     flags = basic_types.UBInt16()
-    actions = []
-    # TODO: Add here a new type, list of ActionHeaders()
-    # objects. Related to ISSUE #3
+    actions = common.ListOfActions()
 
     def __init__(self, xid=None, match=None, cookie=None, command=None,
                  idle_timeout=None, hard_timeout=None, priority=None,
-                 buffer_id=None, out_port=None, flags=None, actions=None):
+                 buffer_id=None, out_port=None, flags=None, actions=[]):
         self.header.message_type = of_header.Type.OFPT_FLOW_MOD
         self.header.length = 0
         self.header.xid = xid

--- a/pyof/v0x01/controller2switch/flow_stats.py
+++ b/pyof/v0x01/controller2switch/flow_stats.py
@@ -6,6 +6,7 @@
 
 # Local source tree imports
 from pyof.v0x01.common import flow_match
+from pyof.v0x01.controller2switch import common
 from pyof.v0x01.foundation import base
 from pyof.v0x01.foundation import basic_types
 
@@ -46,20 +47,16 @@ class FlowStats(base.GenericMessage):
     cookie = basic_types.UBInt64()
     packet_count = basic_types.UBInt64()
     byte_count = basic_types.UBInt64()
-    # actions = basic_types.UBInt8Array(length=0)
-    actions = []
-    # TODO: Add here a new type, list of ActionHeaders()
-    #       objects. Related to ISSUE #3
+    actions = common.ListOfActions()
 
     def __init__(self, length=None, table_id=None, match=None,
                  duration_sec=None, duration_nsec=None, priority=None,
                  idle_timeout=None, hard_timeout=None, cookie=None,
-                 packet_count=None, byte_count=None, actions=None):
+                 packet_count=None, byte_count=None, actions=[]):
 
         self.length = length
         self.table_id = table_id
-        if match is not None:
-            self.match = match
+        self.match = match
         self.duration_sec = duration_sec
         self.duration_nsec = duration_nsec
         self.prioriry = priority
@@ -68,5 +65,4 @@ class FlowStats(base.GenericMessage):
         self.cookie = cookie
         self.packet_count = packet_count
         self.byte_count = byte_count
-        if actions is not None:
-            self.actions = actions
+        self.actions = actions

--- a/pyof/v0x01/controller2switch/packet_out.py
+++ b/pyof/v0x01/controller2switch/packet_out.py
@@ -7,6 +7,7 @@ uses the OFPT_PACKET_OUT message"""
 
 # Local source tree imports
 from pyof.v0x01.common import header as of_header
+from pyof.v0x01.controller2switch import common
 from pyof.v0x01.foundation import base
 from pyof.v0x01.foundation import basic_types
 
@@ -24,6 +25,7 @@ class PacketOut(base.GenericMessage):
                             OFPP_NORMAL, OFPP_FLOOD, and OFPP_ALL cannot be
                             used as an input port.
         :param actions_len: Size of action array in bytes
+        :param actions:     Actions (class ActionHeader)
         :param data:        Packet data. The length is inferred from the length
                             field in the header. (Only meaningful if
                             buffer_id == -1.)
@@ -32,13 +34,15 @@ class PacketOut(base.GenericMessage):
     buffer_id = basic_types.UBInt32()
     in_port = basic_types.UBInt16()
     actions_len = basic_types.UBInt16()
-    data = basic_types.UBInt8Array(length=0)
+    actions = common.ListOfActions()
+    data = basic_types.ConstantTypeList()
 
     def __init__(self, xid=None, buffer_id=None, in_port=None,
-                 actions_len=None, data=None):
+                 actions_len=None, actions=[], data=[]):
         self.header.xid = xid
         self.header.message_type = of_header.Type.OFPT_PACKET_OUT
         self.buffer_id = buffer_id
         self.in_port = in_port
         self.actions_len = actions_len
+        self.actions = actions
         self.data = data

--- a/pyof/v0x01/controller2switch/port_mod.py
+++ b/pyof/v0x01/controller2switch/port_mod.py
@@ -2,9 +2,7 @@
 
 # System imports
 
-
 # Third-party imports
-
 
 # Local source tree imports
 from pyof.v0x01.common import header as of_header

--- a/pyof/v0x01/controller2switch/queue_get_config_reply.py
+++ b/pyof/v0x01/controller2switch/queue_get_config_reply.py
@@ -6,8 +6,24 @@
 
 # Local source tree imports
 from pyof.v0x01.common import header as of_header
+from pyof.v0x01.common import queue
 from pyof.v0x01.foundation import base
 from pyof.v0x01.foundation import basic_types
+
+
+class ListOfQueues(basic_types.FixedTypeList):
+    """List of queues.
+
+    Represented by instances of PacketQueue and
+    used on QueueGetConfigReply objects
+
+    Attributes:
+        items (optional): Instance or a list of instances of PacketQueue
+    """
+    def __init__(self, items=[]):
+        basic_types.FixedTypeList.__init__(self,
+                                           pyof_class=queue.PacketQueue,
+                                           items=items)
 
 
 class QueueGetConfigReply(base.GenericMessage):
@@ -21,13 +37,11 @@ class QueueGetConfigReply(base.GenericMessage):
     header = of_header.Header()
     port = basic_types.UBInt16()
     pad = basic_types.PAD(6)
-    queue = []
-    # TODO: Add here a new type, list of ActionHeaders()
-    # objects. Related to ISSUE #3
+    queues = ListOfQueues()
 
-    def __init__(self, xid=None, port=None, queue=None):
+    def __init__(self, xid=None, port=None, queues=[]):
 
         self.header.message_type = of_header.Type.OFPT_GET_CONFIG_REPLY
         self.header.xid = xid
         self.port = port
-        self.queue = queue
+        self.queues = queues

--- a/pyof/v0x01/controller2switch/set_config.py
+++ b/pyof/v0x01/controller2switch/set_config.py
@@ -15,4 +15,3 @@ class SetConfig(common.SwitchConfig):
         self.__ordered__ = common.SwitchConfig.__ordered__
         common.SwitchConfig.__init__(self, xid, flags, miss_send_len)
         self.header.message_type = of_header.Type.OFPT_SET_CONFIG
-

--- a/pyof/v0x01/controller2switch/stats_reply.py
+++ b/pyof/v0x01/controller2switch/stats_reply.py
@@ -70,10 +70,9 @@ class StatsReply(base.GenericMessage):
     header = of_header.Header()
     body_type = basic_types.UBInt16()
     flags = basic_types.UBInt16()
-    body = basic_types.UBInt8Array(length=0)
+    body = basic_types.ConstantTypeList()
 
-    def __init__(self, xid=None, body_type=None, flags=None,
-                 body=None):
+    def __init__(self, xid=None, body_type=None, flags=None, body=[]):
 
         self.header.xid = xid
         self.header.message_type = of_header.Type.OFPT_STATS_REPLY

--- a/pyof/v0x01/controller2switch/stats_request.py
+++ b/pyof/v0x01/controller2switch/stats_request.py
@@ -22,9 +22,9 @@ class StatsRequest(base.GenericMessage):
     header = of_header.Header()
     body_type = basic_types.UBInt16()
     flags = basic_types.UBInt16()
-    body = basic_types.UBInt8Array(0)
+    body = basic_types.ConstantTypeList()
 
-    def __init__(self, xid=None, body_type=None, flags=None, body=None):
+    def __init__(self, xid=None, body_type=None, flags=None, body=[]):
 
         self.header.message_type = of_header.Type.OFPT_STATS_REQUEST
         self.header.xid = xid

--- a/pyof/v0x01/foundation/base.py
+++ b/pyof/v0x01/foundation/base.py
@@ -131,10 +131,7 @@ class GenericStruct(metaclass=MetaStruct):
     def get_size(self):
         tot = 0
         for _attr, _class in self.__ordered__:
-            if _class is not list:
-                # TODO: Remove this if after creating the
-                # specific new list type. Issue #3
-                tot += getattr(self, _attr).get_size()
+            tot += getattr(self, _attr).get_size()
         return tot
 
     def pack(self):

--- a/pyof/v0x01/foundation/exceptions.py
+++ b/pyof/v0x01/foundation/exceptions.py
@@ -1,22 +1,38 @@
 """Exceptions defined on this Library"""
 
 
-class Exception(Exception):
-    pass
+class MethodNotImplemented(Exception):
+    """Exception to be raised when a method is not implemented"""
+    def __init__(self, message=None):
+        self.message = message
+
+    def __str__(self):
+        if self.message:
+            return self.message
+        else:
+            return "Method not yet implemented"
 
 
 class BadValueException(Exception):
     pass
 
 
-class NoUnpackException(Exception):
+class WrongListItemType(Exception):
+    """Exception used for FixedTypeList and ConstantTypeList classes
+    instances when the user tries to insert an item on this
+    lists that does not match the expected type."""
+    def __init__(self, item_class, expected_class):
+        self.item_class = item_class
+        self.expected_class = expected_class
+
     def __str__(self):
-        return "This class has no 'unpack()' method implemented."
+        message = "'{}' is not an instance of ".format(self.item_class)
+        message = message + "type '{}'".format(self.expected_class)
+        return message
 
 
 class PADHasNoValue(Exception):
-    """Exception raised when the user tries to set a value on a PAD attribute
-    """
+    """Exception raised when user tries to set a value on a PAD attribute"""
     def __str__(self):
         return "You can't set a value on a PAD attribute"
 

--- a/tests/v0x01/test_asynchronous/test_error_msg.py
+++ b/tests/v0x01/test_asynchronous/test_error_msg.py
@@ -12,7 +12,7 @@ class TestErrorMsg(unittest.TestCase):
         self.message.header.xid = 1
         self.message.type = error_msg.ErrorType.OFPET_BAD_ACTION
         self.message.code = error_msg.BadActionCode.OFPBAC_EPERM
-        self.message.data = [0]
+        self.message.data = []
 
     def test_size(self):
         """[Asynchronous/ErrorMsg] - size 12"""

--- a/tests/v0x01/test_common/test_queue.py
+++ b/tests/v0x01/test_common/test_queue.py
@@ -30,13 +30,9 @@ class TestQueuePropHeader(unittest.TestCase):
 class TestPacketQueue(unittest.TestCase):
 
     def setUp(self):
-        propertie01 = queue.QueuePropHeader()
-        propertie01.property = queue.QueueProperties.OFPQT_MIN_RATE
-        propertie01.len = 12
         self.message = queue.PacketQueue()
         self.message.queue_id = 1
         self.message.length = 8
-        self.message.properties = [propertie01]
 
     def test_get_size(self):
         """[Common/PacketQueue] - size 8"""

--- a/tests/v0x01/test_controller2switch/test_flow_mod.py
+++ b/tests/v0x01/test_controller2switch/test_flow_mod.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pyof.v0x01.common import action
+# from pyof.v0x01.common import action
 from pyof.v0x01.common import flow_match
 from pyof.v0x01.common import phy_port
 from pyof.v0x01.controller2switch import flow_mod
@@ -9,9 +9,9 @@ from pyof.v0x01.controller2switch import flow_mod
 class TestFlowMod(unittest.TestCase):
 
     def setUp(self):
-        action_header = action.ActionHeader()
-        action_header.action_type = action.ActionType.OFPAT_SET_VLAN_VID
-        action_header.length = 8
+        # action_header = action.ActionHeader()
+        # action_header.action_type = action.ActionType.OFPAT_SET_VLAN_VID
+        # action_header.length = 8
 
         self.message = flow_mod.FlowMod()
         self.message.header.xid = 1
@@ -24,7 +24,7 @@ class TestFlowMod(unittest.TestCase):
         self.message.buffer_id = 1
         self.message.out_port = phy_port.Port.OFPP_NONE
         self.message.flags = flow_mod.FlowModFlags.OFPFF_EMERG
-        self.message.actions = [action_header]
+        # self.message.actions = [action_header]
         self.message.match.in_port = 80
         self.message.match.dl_src = [1, 2, 3, 4, 5, 6]
         self.message.match.dl_dst = [1, 2, 3, 4, 5, 6]

--- a/tests/v0x01/test_controller2switch/test_flow_stats.py
+++ b/tests/v0x01/test_controller2switch/test_flow_stats.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pyof.v0x01.common import action
+# from pyof.v0x01.common import action
 from pyof.v0x01.common import flow_match
 from pyof.v0x01.controller2switch import flow_stats
 
@@ -8,9 +8,9 @@ from pyof.v0x01.controller2switch import flow_stats
 class TestFlowStats(unittest.TestCase):
 
     def setUp(self):
-        action_header = action.ActionHeader()
-        action_header.action_type = action.ActionType.OFPAT_SET_VLAN_VID
-        action_header.length = 8
+        # action_header = action.ActionHeader()
+        # action_header.action_type = action.ActionType.OFPAT_SET_VLAN_VID
+        # action_header.length = 8
 
         self.message = flow_stats.FlowStats()
         self.message.length = 160
@@ -24,7 +24,7 @@ class TestFlowStats(unittest.TestCase):
         self.message.cookie = 1
         self.message.packet_count = 1
         self.message.byte_count = 1
-        self.message.actions = [action_header]
+        # self.message.actions = [action_header]
         self.message.match.in_port = 80
         self.message.match.dl_src = [1, 2, 3, 4, 5, 6]
         self.message.match.dl_dst = [1, 2, 3, 4, 5, 6]

--- a/tests/v0x01/test_controller2switch/test_packet_out.py
+++ b/tests/v0x01/test_controller2switch/test_packet_out.py
@@ -12,7 +12,8 @@ class TestPacketOut(unittest.TestCase):
         self.message.buffer_id = 5
         self.message.in_pot = phy_port.Port.OFPP_NONE
         self.message.actions_len = 4
-        self.message.data = [0]
+        self.message.actions = []
+        self.message.data = []
 
     def test_get_size(self):
         """[Controller2Switch/PacketOut] - size 16"""


### PR DESCRIPTION
 - Implemented FixedTypeList and ConstantTypeList classes on basic_types

 - Added new SpeciaLists subclasses:
    - ListOfProperties
    - ListOfActions
    - ListOfPhyPorts
    - ListOfQueues

 - Added new exceptions:
    - MethodNotIMplemented
    - WrongListItemType

 - Using the new Special Lists on:
    - ErrorMsg
    - PacketQueue
    - SwitchFeatures
    - FlowMod
    - FlowStats
    - PacketOut
    - QueueGetConfigReply
    - StatsReply
    - StatsRequest

 - Fixed/refactored tests:
    - TestErrorMsg
    - TestFlowMod
    - TestFlwoStats
    - TestPacketOut
    - TestPacketQueue

 - Updating GenericStruct get_size method (removing unnecessary if clause)