### PR TITLE
Refactor in order to accept python basic types as messages attributes.

### DIFF
--- a/pyof/v0x01/common/action.py
+++ b/pyof/v0x01/common/action.py
@@ -163,7 +163,7 @@ class ActionDLAddr(base.GenericMessage):
     """
     dl_addr_type = basic_types.UBInt16()
     length = basic_types.UBInt16()
-    dl_addr = basic_types.UBInt8Array(length=base.OFP_ETH_ALEN)
+    dl_addr = basic_types.HWAddress()
     pad = basic_types.PAD(6)
 
     def __init__(self, dl_addr_type=None, length=None, dl_addr=None):

--- a/pyof/v0x01/common/flow_match.py
+++ b/pyof/v0x01/common/flow_match.py
@@ -85,8 +85,8 @@ class Match(base.GenericMessage):
     # Attributes
     wildcards = basic_types.UBInt32()
     in_port = basic_types.UBInt16()
-    dl_src = basic_types.UBInt8Array(length=base.OFP_ETH_ALEN)
-    dl_dst = basic_types.UBInt8Array(length=base.OFP_ETH_ALEN)
+    dl_src = basic_types.HWAddress()
+    dl_dst = basic_types.HWAddress()
     dl_vlan = basic_types.UBInt16()
     dl_vlan_pcp = basic_types.UBInt8()
     pad1 = basic_types.PAD(1)

--- a/pyof/v0x01/common/phy_port.py
+++ b/pyof/v0x01/common/phy_port.py
@@ -161,7 +161,7 @@ class PhyPort(base.GenericMessage):
 
     """
     port_no = basic_types.UBInt16()
-    hw_addr = basic_types.UBInt8Array(length=base.OFP_ETH_ALEN)
+    hw_addr = basic_types.HWAddress()
     name = basic_types.Char(length=base.OFP_MAX_PORT_NAME_LEN)
     config = basic_types.UBInt32()
     state = basic_types.UBInt32()

--- a/pyof/v0x01/controller2switch/port_mod.py
+++ b/pyof/v0x01/controller2switch/port_mod.py
@@ -31,7 +31,7 @@ class PortMod(base.GenericMessage):
     """
     header = of_header.Header()
     port_no = basic_types.UBInt16()
-    hw_addr = basic_types.UBInt8Array(length=base.OFP_ETH_ALEN)
+    hw_addr = basic_types.HWAddress()
     config = basic_types.UBInt32()
     mask = basic_types.UBInt32()
     advertise = basic_types.UBInt32()

--- a/pyof/v0x01/foundation/exceptions.py
+++ b/pyof/v0x01/foundation/exceptions.py
@@ -47,12 +47,21 @@ class AttributeTypeError(Exception):
         self.expected_class = expected_class
 
     def __str__(self):
-        return ("Unexpected value ('{}') on attribute '{}' "
-                "from class '{}'".format(self.item,
-                                         self.name, self.expected_class))
+        msg = "Unexpected value ('{}') ".format(str(self.item))
+        msg += "on attribute '{}' ".format(str(self.name))
+        msg += "from class '{}'".format(str(self.expected_class))
+        return msg
 
 
 class NotBinaryData(Exception):
     """Error raised when the content of a BinaryData attribute is not binary"""
     def __str__(self):
         return("The content of this variable needs to be binary data")
+
+
+class ValidationError(Exception):
+    """Error on validate message or struct"""
+    def __init__(self, msg="Error on validate message"):
+        self.msg = msg
+    def __str__(self):
+        return self.msg

--- a/pyof/v0x01/symmetric/echo_reply.py
+++ b/pyof/v0x01/symmetric/echo_reply.py
@@ -20,6 +20,7 @@ class EchoReply(base.GenericMessage):
     header = of_header.Header()
 
     def __init__(self, xid=None):
+        self.header = of_header.Header()
         self.header.message_type = of_header.Type.OFPT_ECHO_REPLY
         self.header.length = 8
         self.header.xid = xid

--- a/tests/v0x01/test_common/test_action.py
+++ b/tests/v0x01/test_common/test_action.py
@@ -81,6 +81,7 @@ class TestActionVlanVid(unittest.TestCase):
 
     def setUp(self):
         self.message = action.ActionVlanVid()
+        self.message.length = 2
         self.message.vlan_vid = 5
 
     def test_get_size(self):
@@ -129,6 +130,7 @@ class TestActionDLAddr(unittest.TestCase):
     def test_get_size(self):
         """[Common/ActionDLAddr] - size 16"""
         self.assertEqual(self.message.get_size(), 16)
+
 
     @unittest.skip('Not yet implemented')
     def test_pack(self):
@@ -211,7 +213,7 @@ class TestActionVendorHeader(unittest.TestCase):
 
     def setUp(self):
         self.message = action.ActionVendorHeader()
-        self.message.len = 16
+        self.message.length = 16
         self.message.vendor = 1
 
     def test_get_size(self):

--- a/tests/v0x01/test_common/test_phy_port.py
+++ b/tests/v0x01/test_common/test_phy_port.py
@@ -9,7 +9,7 @@ class TestPhyPort(unittest.TestCase):
     def setUp(self):
         self.message = phy_port.PhyPort()
         self.message.port_no = 2
-        self.message.hw_addr = [10, 10, 18, 18, 16, 16]
+        self.message.hw_addr = '1a:2b:3c:4d:5e:6f'
         self.message.name = bytes('X' * base.OFP_MAX_PORT_NAME_LEN, 'utf-8')
         self.message.config = phy_port.PortConfig.OFPPC_NO_STP
         self.message.state = phy_port.PortState.OFPPS_STP_FORWARD

--- a/tests/v0x01/test_controller2switch/test_port_mod.py
+++ b/tests/v0x01/test_controller2switch/test_port_mod.py
@@ -1,7 +1,6 @@
 import unittest
 
 from pyof.v0x01.controller2switch import port_mod
-from pyof.v0x01.foundation import base
 
 
 class TestPortMod(unittest.TestCase):
@@ -10,7 +9,7 @@ class TestPortMod(unittest.TestCase):
         self.message = port_mod.PortMod()
         self.message.header.xid = 1
         self.message.port_no = 80
-        self.message.hw_addr = [1 for _ in range(base.OFP_ETH_ALEN)]
+        self.message.hw_addr = 'aa:bb:cc:00:33:9f'
         self.message.config = 1 << 2
         self.message.mask = 1 << 1
         self.message.advertise = 1

--- a/tests/v0x01/test_foundation/test_basic_types.py
+++ b/tests/v0x01/test_foundation/test_basic_types.py
@@ -25,29 +25,6 @@ class TestUBInt8(unittest.TestCase):
         pass
 
 
-class TestUBInt8Array(unittest.TestCase):
-
-    def setUp(self):
-        self.item = basic_types.UBInt8Array(value=[15, 15, 15, 15, 15, 15],
-                                            length=6)
-
-    def test_size(self):
-        """[Foundation/BasicTypes/UBInt8Array] - size 6"""
-        self.assertEqual(self.item.get_size(), 6)
-
-    @unittest.skip('Not yet implemented')
-    def test_pack(self):
-        """[Foundation/BasicTypes/UBInt8Array] - packing"""
-        # TODO
-        pass
-
-    @unittest.skip('Not yet implemented')
-    def test_unpack(self):
-        """[Foundation/BasicTypes/UBInt8Array] - unpacking"""
-        # TODO
-        pass
-
-
 class TestUBInt16(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
The messages now convert the type during the pack operation.

#changelog: Refactor in order to accept python basic types as messages attributes.