### PR TITLE
Remove warnings and errors of doc build

### DIFF
--- a/pyof/__init__.py
+++ b/pyof/__init__.py
@@ -3,6 +3,3 @@
 This package is a library that parses and creates OpenFlow Messages.
 It contains all implemented versions of OpenFlow protocol
 """
-# Variable that contains all the implemented versions of the protocol
-# on this library. They should be ordered from older to newer versions.
-__all__ = ['v0x01']

--- a/pyof/v0x01/asynchronous/error_msg.py
+++ b/pyof/v0x01/asynchronous/error_msg.py
@@ -49,27 +49,27 @@ class HelloFailedCode(enum.Enum):
 
 class BadRequestCode(enum.Enum):
     """Error_msg 'code' values for OFPET_BAD_REQUEST.
-    'data' contains at least the first 64 bytes of the failed request.
 
-        OFPBRC_BAD_VERSION     # ofp_header.version not supported.
-        OFPBRC_BAD_TYPE        # ofp_header.type not supported.
-        OFPBRC_BAD_STAT        # ofp_stats_request.type not supported.
-        OFPBRC_BAD_VENDOR      # Vendor not supported (in ofp_vendor_header
-                                 or ofp_stats_request or ofp_stats_reply).
-        OFPBRC_BAD_SUBTYPE     # Vendor subtype not supported.
-        OFPBRC_EPERM           # Permissions error.
-        OFPBRC_BAD_LEN         # Wrong request length for type.
-        OFPBRC_BUFFER_EMPTY    # Specified buffer has already been used.
-        OFPBRC_BUFFER_UNKNOWN  # Specified buffer does not exist.
+    'data' contains at least the first 64 bytes of the failed request.
     """
-    OFPBRC_BAD_VERSION = 1,
-    OFPBRC_BAD_TYPE = 2,
-    OFPBRC_BAD_STAT = 3,
-    OFPBRC_BAD_VENDOR = 4,
-    OFPBRC_BAD_SUBTYPE = 5,
-    OFPBRC_EPERM = 6,
-    OFPBRC_BAD_LEN = 7,
-    OFPBRC_BUFFER_EMPTY = 8,
+    #: ofp_header.version not supported.
+    OFPBRC_BAD_VERSION = 1
+    #: ofp_header.type not supported.
+    OFPBRC_BAD_TYPE = 2
+    #: ofp_stats_request.type not supported.
+    OFPBRC_BAD_STAT = 3
+    #: Vendor not supported (in ofp_vendor_header or ofp_stats_request or
+    #: ofp_stats_reply).
+    OFPBRC_BAD_VENDOR = 4
+    #: Vendor subtype not supported.
+    OFPBRC_BAD_SUBTYPE = 5
+    #: Permissions error.
+    OFPBRC_EPERM = 6
+    #: Wrong request length for type.
+    OFPBRC_BAD_LEN = 7
+    #: Specified buffer has already been used.
+    OFPBRC_BUFFER_EMPTY = 8
+    #: Specified buffer does not exist.
     OFPBRC_BUFFER_UNKNOWN = 9
 
 
@@ -100,24 +100,20 @@ class BadActionCode(enum.Enum):
 
 class FlowModFailedCode(enum.Enum):
     """Error_msg 'code' values for OFPET_FLOW_MOD_FAILED.
+
     'data' contains at least the first 64 bytes of the failed request.
-
-        OFPFMFC_ALL_TABLES_FULL    # Flow not added because of full tables
-        OFPFMFC_OVERLAP            # Attempted to add overlapping flow with
-                                     CHECK_OVERLAP flag set
-        OFPFMFC_EPERM              # Permissions error
-        OFPFMFC_BAD_EMERG_TIMEOUT  # Flow not added because of non-zero
-                                     idle/hard timeout
-        OFPFMFC_BAD_COMMAND        # Unknown command
-        OFPFMFC_UNSUPPORTED        # Unsupported action list - cannot process
-                                     in the order specified
-
     """
-    OFPFMFC_ALL_TABLES_FULL = 1,
-    OFPFMFC_OVERLAP = 2,
-    OFPFMFC_EPERM = 3,
-    OFPFMFC_BAD_EMERG_TIMEOUT = 4,
-    OFPFMFC_BAD_COMMAND = 5,
+    #: Flow not added because of full tables
+    OFPFMFC_ALL_TABLES_FULL = 1
+    #: Attempted to add overlapping flow with CHECK_OVERLAP flag set
+    OFPFMFC_OVERLAP = 2
+    #: Permissions error
+    OFPFMFC_EPERM = 3
+    #: Flow not added because of non-zero idle/hard timeout
+    OFPFMFC_BAD_EMERG_TIMEOUT = 4
+    #: Unknown command
+    OFPFMFC_BAD_COMMAND = 5
+    #: Unsupported action list - cannot process in the order specified
     OFPFMFC_UNSUPPORTED = 6
 
 

--- a/pyof/v0x01/asynchronous/flow_removed.py
+++ b/pyof/v0x01/asynchronous/flow_removed.py
@@ -30,24 +30,21 @@ class FlowRemovedReason(enum.Enum):
 
 # Classes
 class FlowRemoved(base.GenericStruct):
-    """
-    Flow removed (datapath -> controller).
+    """Flow removed (datapath -> controller).
 
-        :param header:        Openflow Header
-        :param match:         Description of Fields
-        :param cookie:        Opaque controller-issued identifier
-        :param priority:      Priority level of flow entry
-        :param reason:        One of OFPRR_*
-        :param pad :          Align to 32-bits
-        :param duration_sec:  Time flow was alive in seconds
-        :param duration_nsec: Time flow was alive in nanoseconds beyond
-                              duration_sec
-        :param idle_timeout:  Idle timeout from original flow mod
-        :param pad2:          Align to 64-bits
-        :param packet_count:  Number of packets
-        :param byte_count:    Bytes count
-
-
+    :param header:        Openflow Header
+    :param match:         Description of Fields
+    :param cookie:        Opaque controller-issued identifier
+    :param priority:      Priority level of flow entry
+    :param reason:        One of OFPRR_*
+    :param pad:           Align to 32-bits
+    :param duration_sec:  Time flow was alive in seconds
+    :param duration_nsec: Time flow was alive in nanoseconds beyond
+                          duration_sec
+    :param idle_timeout:  Idle timeout from original flow mod
+    :param pad2:          Align to 64-bits
+    :param packet_count:  Number of packets
+    :param byte_count:    Bytes count
     """
     header = of_header.Header()
     match = flow_match.Match()

--- a/pyof/v0x01/common/action.py
+++ b/pyof/v0x01/common/action.py
@@ -52,7 +52,7 @@ class ActionHeader(base.GenericMessage):
     """
     Defines the Header that is common to all actions.
 
-        :param action_type: One of OFPAT_.
+        :param action_type: One of OFPAT\_.
         :param length:     Length of action, including this header.
         :param pad:        Pad for 64-bit alignment.
     """

--- a/pyof/v0x01/common/phy_port.py
+++ b/pyof/v0x01/common/phy_port.py
@@ -64,37 +64,31 @@ class PortState(enum.Enum):
 
 
 class Port(enum.Enum):
-    """Port numbering. Physical ports are numbered starting from 1. Port number
-    0 is reserved by the specification and must not be used for a switch
-    physical port.
+    """Port numbering.
 
-    Enums:
-        OFPP_MAX         # Maximum number of physical switch ports.
-        OFPP_IN_PORT     # Send the packet out the input port. This
-                         # virtual port must be explicitly used
-                         # in order to send back out of the input port.
-
-        OFPP_TABLE       # Perform actions in flow table.
-                         # NB: This can only be the destination
-                         # port for packet-out messages
-
-        OFPP_NORMAL      # Process with normal L2/L3 switching.
-        OFPP_FLOOD       # All physical ports except input port and
-                         # those disabled by STP
-        OFPP_ALL         # All physical ports except input port
-        OFPP_CONTROLLER  # Send to controller
-        OFPP_LOCAL       # Local openflow "port"
-        OFPP_NONE        # Not associated with a physical port
+    Physical ports are numbered starting from 1. Port number 0 is reserved by
+    the specification and must not be used for a switch physical port.
     """
 
+    #: Maximum number of physical switch ports.
     OFPP_MAX = 0xff00
+    #: Send the packet out the input port. This virtual port must be explicitly
+    #: used in order to send back out of the input port.
     OFPP_IN_PORT = 0xfff8
+    #: Perform actions in flow table.
+    #: NB: This can only be the destination port for packet-out messages
     OFPP_TABLE = 0xfff9
+    #: Process with normal L2/L3 switching.
     OFPP_NORMAL = 0xfffa
+    #: All physical ports except input port and
     OFPP_FLOOD = 0xfffb
+    #: All physical ports except input port
     OFPP_ALL = 0xfffc
+    #: Send to controller
     OFPP_CONTROLLER = 0xfffd
+    #: Local openflow "port"
     OFPP_LOCAL = 0xfffe
+    #: Not associated with a physical port
     OFPP_NONE = 0xffff
 
 

--- a/pyof/v0x01/common/queue.py
+++ b/pyof/v0x01/common/queue.py
@@ -45,7 +45,7 @@ class ListOfProperties(basic_types.FixedTypeList):
 class QueuePropHeader(base.GenericStruct):
     """This class describes the header of each queue property.
 
-        :param property: One of OFPQT_.
+        :param property: One of OFPQT\_.
         :param len:      Length of property, including this header.
         :param pad:      64-bit alignment.
     """
@@ -61,10 +61,10 @@ class QueuePropHeader(base.GenericStruct):
 class PacketQueue(base.GenericStruct):
     """This class describes a queue.
 
-        :param queue_id: One of OFPQT_
+        :param queue_id: One of OFPQT\_
         :param length:   Length of property, including this header
-        :param pad
-        :param properties
+        :param pad:
+        :param properties:
     """
     queue_id = basic_types.UBInt32()
     length = basic_types.UBInt16()

--- a/pyof/v0x01/controller2switch/flow_mod.py
+++ b/pyof/v0x01/controller2switch/flow_mod.py
@@ -25,6 +25,7 @@ class FlowModCommand(enum.Enum):
         OFPFC_MODIFY_STRICT # Modify entry strictly matching wildcards
         OFPFC_DELETE        # Delete all matching flows
         OFPFC_DELETE_STRICT # Strictly match wildcards and priority
+
     """
     OFPFC_ADD = 1
     OFPFC_MODIFY = 2
@@ -34,17 +35,13 @@ class FlowModCommand(enum.Enum):
 
 
 class FlowModFlags(enum.Enum):
-    """
-    Types to be used in Flags field
+    """Types to be used in Flags field"""
 
-    Enums:
-        OFPFF_SEND_FLOW_REM # Send flow removed message when flow
-                              expires or is deleted
-        OFPFF_CHECK_OVERLAP # Check for overlapping entries first
-        OFPFF_EMERG         # Remark this is for emergency
-    """
+    #: Send flow removed message when flow expires or is deleted
     OFPFF_SEND_FLOW_REM = 1 << 0
+    #: Check for overlapping entries first
     OFPFF_CHECK_OVERLAP = 1 << 1
+    #: Remark this is for emergency
     OFPFF_EMERG = 1 << 2
 
 


### PR DESCRIPTION
Fix #41. There's only one error because v0x02 code is broken. Devs should check doc output before commit. There are still many comments to be rewritten using Sphinx style. For me, enum name has white font color in a white background, so maybe we should change the doc's theme.