### PR TITLE
Issue #78 pylint

### DIFF
--- a/pyof/v0x01/controller2switch/features_reply.py
+++ b/pyof/v0x01/controller2switch/features_reply.py
@@ -78,6 +78,6 @@ class SwitchFeatures(base.GenericMessage):
 class FeaturesReply(SwitchFeatures):
     def __init__(self, xid=None, datapath_id=None, n_buffers=None,
                  n_tables=None, capabilities=None, actions=None, ports=None):
-        self.__ordered__ = super().__ordered__
+        self.__ordered__ = super().__ordered__  # pylint: disable=no-member
         super().__init__(xid, datapath_id, n_buffers, n_tables, capabilities,
                          actions, ports)

--- a/pyof/v0x01/controller2switch/get_config_reply.py
+++ b/pyof/v0x01/controller2switch/get_config_reply.py
@@ -12,6 +12,6 @@ from pyof.v0x01.controller2switch import common
 class GetConfigReply(common.SwitchConfig):
 
     def __init__(self, xid=None, flags=None, miss_send_len=None):
-        self.__ordered__ = super().__ordered__
+        self.__ordered__ = super().__ordered__  # pylint: disable=no-member
         super().__init__(xid, flags, miss_send_len)
         self.header.message_type = of_header.Type.OFPT_SET_CONFIG

--- a/pyof/v0x01/controller2switch/set_config.py
+++ b/pyof/v0x01/controller2switch/set_config.py
@@ -12,6 +12,6 @@ from pyof.v0x01.controller2switch import common
 class SetConfig(common.SwitchConfig):
 
     def __init__(self, xid=None, flags=None, miss_send_len=None):
-        self.__ordered__ = super().__ordered__
+        self.__ordered__ = super().__ordered__  # pylint: disable=no-member
         super().__init__(xid, flags, miss_send_len)
         self.header.message_type = of_header.Type.OFPT_SET_CONFIG

--- a/pyof/v0x01/foundation/base.py
+++ b/pyof/v0x01/foundation/base.py
@@ -197,6 +197,7 @@ class GenericStruct(object, metaclass=MetaStruct):
         """
         return self.pack() == other.pack()
 
+    @staticmethod
     def _attr_fits_into_class(attr, _class):
         if not isinstance(attr, _class):
             try:
@@ -213,7 +214,7 @@ class GenericStruct(object, metaclass=MetaStruct):
             if isinstance(attr, _class):
                 return True
             elif issubclass(_class, GenericType):
-                if GenericStruct._fits_into_generic_type(attr, _class):
+                if GenericStruct._attr_fits_into_class(attr, _class):
                     return True
             elif not isinstance(attr, _class):
                 return False

--- a/pyof/v0x01/foundation/basic_types.py
+++ b/pyof/v0x01/foundation/basic_types.py
@@ -155,7 +155,7 @@ class BinaryData(base.GenericType):
             else:
                 return b''
         else:
-            raise exceptions.NotBinarydata()
+            raise exceptions.NotBinaryData()
 
     def unpack(self, buff, offset):
         self._value = buff

--- a/pyof/v0x01/foundation/basic_types.py
+++ b/pyof/v0x01/foundation/basic_types.py
@@ -24,6 +24,7 @@ class PAD(base.GenericType):
     _fmt = ''
 
     def __init__(self, length=0):
+        super().__init__()
         self._length = length
 
     def __repr__(self):
@@ -36,13 +37,14 @@ class PAD(base.GenericType):
         """ Return the size of type in bytes. """
         return struct.calcsize("!{:d}B".format(self._length))
 
-    def unpack(self, buff, offset):
+    def unpack(self, buff, offset=0):
         """Unpack a buff and stores at value property.
-            :param buff:   Buffer where data is located.
-            :param offset: Where data stream begins.
-            Do nothing, since the _length is already defined
-            and it is just a PAD. Keep buff and offset just
-            for compability with other unpack methods
+
+        Do nothing, since the _length is already defined and it is just a PAD.
+        Keep buff and offset just for compability with other unpack methods.
+
+        :param buff:   Buffer where data is located.
+        :param offset: Where data stream begins.
         """
         pass
 
@@ -149,7 +151,7 @@ class BinaryData(base.GenericType):
         super().__init__(value)
 
     def pack(self):
-        if type(self._value) is bytes:
+        if isinstance(self._value, bytes):
             if len(self._value) > 0:
                 return self._value
             else:
@@ -157,7 +159,7 @@ class BinaryData(base.GenericType):
         else:
             raise exceptions.NotBinaryData()
 
-    def unpack(self, buff, offset):
+    def unpack(self, buff, offset=0):
         self._value = buff
 
     def get_size(self):
@@ -171,7 +173,7 @@ class FixedTypeList(list, base.GenericStruct):
     def __init__(self, pyof_class, items=None):
         super().__init__()
         self._pyof_class = pyof_class
-        if type(items) is list:
+        if isinstance(items, list):
             self.extend(items)
         elif items:
             self.append(items)
@@ -181,7 +183,7 @@ class FixedTypeList(list, base.GenericStruct):
         return "{}".format([str(item) for item in self])
 
     def append(self, item):
-        if type(item) is list:
+        if isinstance(item, list):
             self.extend(item)
         elif item.__class__ == self._pyof_class:
             list.append(self, item)
@@ -242,7 +244,7 @@ class ConstantTypeList(list, base.GenericStruct):
     be inserted"""
     def __init__(self, items=None):
         super().__init__()
-        if type(items) is list:
+        if isinstance(items, list):
             self.extend(items)
         elif items:
             self.append(items)
@@ -252,7 +254,7 @@ class ConstantTypeList(list, base.GenericStruct):
         return "{}".format([str(item) for item in self])
 
     def append(self, item):
-        if type(item) is list:
+        if isinstance(item, list):
             self.extend(item)
         elif len(self) == 0:
             list.append(self, item)

--- a/pyof/v0x01/foundation/exceptions.py
+++ b/pyof/v0x01/foundation/exceptions.py
@@ -47,9 +47,9 @@ class AttributeTypeError(Exception):
         self.expected_class = expected_class
 
     def __str__(self):
-        msg = "Unexpected value ('{}') ".format(str(self.item))
-        msg += "on attribute '{}' ".format(str(self.name))
-        msg += "from class '{}'".format(str(self.expected_class))
+        msg = "Unexpected value '{}' ".format(str(self.item))
+        msg += "with class '{}' ".format(str(self.item_class))
+        msg += "and expected class '{}'".format(str(self.expected_class))
         return msg
 
 

--- a/pyof/v0x01/foundation/exceptions.py
+++ b/pyof/v0x01/foundation/exceptions.py
@@ -4,6 +4,7 @@
 class MethodNotImplemented(Exception):
     """Exception to be raised when a method is not implemented"""
     def __init__(self, message=None):
+        super().__init__()
         self.message = message
 
     def __str__(self):
@@ -22,6 +23,7 @@ class WrongListItemType(Exception):
     instances when the user tries to insert an item on this
     lists that does not match the expected type."""
     def __init__(self, item_class, expected_class):
+        super().__init__()
         self.item_class = item_class
         self.expected_class = expected_class
 
@@ -42,6 +44,7 @@ class AttributeTypeError(Exception):
     defined on the class definition"""
 
     def __init__(self, item, item_class, expected_class):
+        super().__init__()
         self.item = item
         self.item_class = item_class
         self.expected_class = expected_class
@@ -56,12 +59,13 @@ class AttributeTypeError(Exception):
 class NotBinaryData(Exception):
     """Error raised when the content of a BinaryData attribute is not binary"""
     def __str__(self):
-        return("The content of this variable needs to be binary data")
+        return "The content of this variable needs to be binary data"
 
 
 class ValidationError(Exception):
     """Error on validate message or struct"""
     def __init__(self, msg="Error on validate message"):
+        super().__init__()
         self.msg = msg
 
     def __str__(self):


### PR DESCRIPTION
There were some bugs like a misspelled class name that we can avoid by integrating pylint in the editor.

Pylint doesn't recognize members from metaclasses, but we shouldn't ignore these warnings in the whole project. Therefore, I used code comments to ignore missing `__ordered__` member.