### PR TITLE
[docs] Improve livehtml to use dirhtml instead of html sphinx build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,7 +21,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 default:
 	make clean
-	make html
+	make dirhtml
 
 
 .PHONY: help
@@ -238,4 +238,4 @@ dummy:
 	@echo "Build finished. Dummy builder generates no files."
 
 livehtml:
-	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -z ../pyof
+	sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/html -z ../pyof


### PR DESCRIPTION
Just a small improvement. Now, while using 'livehtml' or using the default docs build, our docs will have links without the ".html" end.