### PR TITLE
Remove v0x02

### DIFF
--- a/pyof/v0x02/__init__.py
+++ b/pyof/v0x02/__init__.py
@@ -1,1 +1,0 @@
-"""The ofx parser package - spec version 0x02 (1.1)."""

--- a/pyof/v0x02/common/__init__.py
+++ b/pyof/v0x02/common/__init__.py
@@ -1,1 +1,0 @@
-"""Common Messages from OpenFlow Protocol."""

--- a/pyof/v0x04/common/port.py
+++ b/pyof/v0x04/common/port.py
@@ -151,7 +151,7 @@ class PortState(GenericBitMask):
 
     All port state bits are read-only and cannot be changed by the controller.
     When the port flags are changed, the switch sends an
-    :attr:`v0x02.common.header.Type.OFPT_PORT_STATUS` message to notify the
+    :attr:`v0x04.common.header.Type.OFPT_PORT_STATUS` message to notify the
     controller of the change.
     """
 

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(name='python-openflow',
       test_suite='tests',
       include_package_data=True,
       install_requires=requirements,
-      packages=find_packages(exclude=['tests', '*v0x02*']),
+      packages=find_packages(exclude=['tests']),
       cmdclass={
           'clean': Cleaner,
           'coverage': TestCoverage,


### PR DESCRIPTION
It is not implemented. There were only 2 `__init__.py` files.