### PR TITLE
[minor] Downgrade pylama

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
 # For developers, the packages below are required.
-tox ~= 2.7
+tox ~= 2.7.0
 
 # For running doctests (during "python setup.py test")
 Sphinx == 1.5.6
 sphinx_bootstrap_theme == 0.4.14
 
 # Linters
-pydocstyle ~= 1.1
-pylama ~= 7.3
-pylama_pylint ~= 3.0
-radon ~= 1.5
+pydocstyle ~= 1.1.1
+pylama ~= 7.3.3
+pylama_pylint ~= 3.0.1
+radon ~= 1.5.0
 
 # Code coverage
-coverage >= 4.1
+coverage >= 4.4.1

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,4 @@ commands=
 
 deps=
     -rrequirements-dev.txt
+    -rrequirements-docs.txt


### PR DESCRIPTION
After last Pylama release, we have new linter warnings to be fixed in
a later version.