### PR TITLE
Match fix

### DIFF
--- a/pyof/foundation/base.py
+++ b/pyof/foundation/base.py
@@ -130,6 +130,9 @@ class GenericType:
         else:
             return self._value
 
+    def _get_new_instance(self, value):
+        return type(self)(value)
+
     def _work_or_pass(self, value, work_func):
         if value is None:
             return getattr(self, work_func)()
@@ -140,7 +143,7 @@ class GenericType:
             value = value.value
 
         try:
-            new_item = type(self)(value=value)
+            new_item = self._get_new_instance(value)
             if hasattr(self, 'enum_ref'):
                 new_item.enum_ref = self.enum_ref
         except Exception as e:  # noqa - there is no generic Initialization Exception...

--- a/pyof/foundation/base.py
+++ b/pyof/foundation/base.py
@@ -264,6 +264,15 @@ class GenericType:
 
 
 class GenericUBIntType(GenericType):
+    r"""Base class for a generic Uint type.
+
+    example:
+        class Uint8(GenericUBIntType):
+            _buff_size = 1
+
+        Uint8.pack(255)
+        b'\xff'
+    """
 
     _buff_size = 0
 
@@ -523,10 +532,10 @@ class GenericStruct(object, metaclass=MetaStruct):
               too.
     """
 
-    def __init__(self):
+    def __init__(self, value=None):
         """Contructor takes no argument and stores attributes' deep copies."""
-        for name, value in self.get_class_attributes():
-            setattr(self, name, deepcopy(value))
+        for name, att_value in self.get_class_attributes():
+            setattr(self, name, deepcopy(att_value))
 
     def __eq__(self, other):
         """Check whether two structures have the same structure and values.
@@ -654,14 +663,13 @@ class GenericStruct(object, metaclass=MetaStruct):
             return getattr(self, work_func)()
         elif isinstance(value, type(self)):
             return getattr(value, work_func)()
-        else:
-            try:
-                new_item = type(self)(value)
-            except:  # noqa - there is no generic Initialization Exception...
-                msg = "{} is not an instance of {}".format(value,
-                                                           type(self).__name__)
-                raise PackException(msg)
-            return getattr(new_item, work_func)()
+        try:
+            new_item = type(self)(value)
+        except:  # noqa - there is no generic Initialization Exception...
+            msg = "{} is not an instance of {}".format(value,
+                                                       type(self).__name__)
+            raise PackException(msg)
+        return getattr(new_item, work_func)()
 
     def _get_size(self):
         return sum(cls_val.get_size(obj_val)

--- a/pyof/foundation/base.py
+++ b/pyof/foundation/base.py
@@ -140,8 +140,11 @@ class GenericType:
             value = value.value
 
         try:
-            new_item = type(self)(value=value, enum_ref=self.enum_ref)
-        except:  # noqa - there is no generic Initialization Exception...
+            new_item = type(self)(value=value)
+            if hasattr(self, 'enum_ref'):
+                new_item.enum_ref = self.enum_ref
+        except Exception as e:  # noqa - there is no generic Initialization Exception...
+            print(e.args)
             msg = "{} is not an instance of {}".format(value,
                                                        type(self).__name__)
             raise PackException(msg)

--- a/pyof/foundation/base.py
+++ b/pyof/foundation/base.py
@@ -139,7 +139,12 @@ class GenericType:
             # if it is enum or bitmask gets only the 'int' value
             value = value.value
 
-        new_item = type(self)(value=value, enum_ref=self.enum_ref)
+        try:
+            new_item = type(self)(value=value, enum_ref=self.enum_ref)
+        except:  # noqa - there is no generic Initialization Exception...
+            msg = "{} is not an instance of {}".format(value,
+                                                       type(self).__name__)
+            raise PackException(msg)
         return getattr(new_item, work_func)()
 
     def pack(self, value=None):
@@ -604,9 +609,13 @@ class GenericStruct(object, metaclass=MetaStruct):
         elif isinstance(value, type(self)):
             return getattr(value, work_func)()
         else:
-            msg = "{} is not an instance of {}".format(value,
-                                                       type(self).__name__)
-            raise PackException(msg)
+            try:
+                new_item = type(self)(value)
+            except:  # noqa - there is no generic Initialization Exception...
+                msg = "{} is not an instance of {}".format(value,
+                                                           type(self).__name__)
+                raise PackException(msg)
+            return getattr(new_item, work_func)()
 
     def _get_size(self):
         return sum(cls_val.get_size(obj_val)

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -314,12 +314,28 @@ class BinaryData(GenericType):
         """
         if value is None:
             value = b''
-        if not isinstance(value, bytes):
-            raise ValueError('BinaryData must contain bytes.')
+
+        value = self._pack_if_necessary(value)
         super().__init__(value, enum_ref=enum_ref)
+
+    def _pack_if_necessary(self, value):
+        if hasattr(value, 'pack') and callable(value.pack):
+            value = value.pack()
+
+        if not isinstance(value, bytes):
+            msg = 'BinaryData value must contain bytes or have pack method; '
+            msg += 'Received type {} value: {}'.format(type(value), value)
+            raise ValueError(msg)
+
+        return value
 
     def _pack(self):
         return self._value
+
+    def pack(self, value=None):
+        if value is not None:
+            value = self._pack_if_necessary(value)
+        return super().pack(value)
 
     def unpack(self, buff, offset=0):
         """Unpack a binary message into this object's attributes.

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -303,7 +303,7 @@ class BinaryData(GenericType):
     return the size of the instance using Python's :func:`len`.
     """
 
-    def __init__(self, value=b''):  # noqa
+    def __init__(self, value=None, enum_ref=None):  # noqa
         """The constructor takes the parameter below.
 
         Args:
@@ -312,6 +312,8 @@ class BinaryData(GenericType):
         Raises:
             ValueError: If given value is not bytes.
         """
+        if value is None:
+            value = b''
         if not isinstance(value, bytes):
             raise ValueError('BinaryData must contain bytes.')
         super().__init__(value, enum_ref=enum_ref)

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -134,7 +134,7 @@ class DPID(GenericType):
         begin = offset
         hexas = []
         while begin < offset + 8:
-            number = struct.unpack("!B", buff[begin:begin+1])[0]
+            number = struct.unpack("!B", buff[begin:begin + 1])[0]
             hexas.append("%.2x" % number)
             begin += 1
         self._value = ':'.join(hexas)
@@ -229,7 +229,7 @@ class IPAddress(GenericType):
             Exception: If there is a struct unpacking error.
         """
         try:
-            unpacked_data = struct.unpack('!4B', buff[offset:offset+4])
+            unpacked_data = struct.unpack('!4B', buff[offset:offset + 4])
             self._value = '.'.join([str(x) for x in unpacked_data])
         except struct.error as e:
             raise exceptions.UnpackException('%s; %s: %s' % (e, offset, buff))
@@ -280,7 +280,7 @@ class HWAddress(GenericType):
             return "{0:0{1}x}".format(n, 2)
 
         try:
-            unpacked_data = struct.unpack('!6B', buff[offset:offset+6])
+            unpacked_data = struct.unpack('!6B', buff[offset:offset + 6])
         except struct.error as e:
             raise exceptions.UnpackException('%s; %s: %s' % (e, offset, buff))
 

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -331,7 +331,8 @@ class BinaryData(GenericType):
         value = self._pack_if_necessary(value)
         super().__init__(value, enum_ref=enum_ref)
 
-    def _pack_if_necessary(self, value):
+    @staticmethod
+    def _pack_if_necessary(value):
         if hasattr(value, 'pack') and callable(value.pack):
             value = value.pack()
 
@@ -346,6 +347,7 @@ class BinaryData(GenericType):
         return self._value
 
     def pack(self, value=None):
+        """Pack the struct in a binary representation."""
         if value is not None:
             value = self._pack_if_necessary(value)
         return super().pack(value)
@@ -402,7 +404,7 @@ class TypeList(GenericStruct, list):
         bin_message = b''
         try:
             for item in self:
-                bin_message += item._pack()
+                bin_message += item._pack()  # noqa
             return bin_message
         except exceptions.PackException as err:
             msg = "{} pack error: {}".format(type(self).__name__, err)
@@ -573,16 +575,15 @@ class ConstantTypeList(TypeList):
 
 
 def get_custom_tlv_class(type_size=3, length_size=1):
-    """ Generate a CUstomTLV class
+    """Generate a CUstomTLV class.
 
     Create a CustomTLV class with the defined number of bytes for type and
     length fields.
 
     Args:
-        type_size (int): length in bytes for the type field of the TLV
-        length_size (int): length in bytes for the length field of the TLV
+        type_size (int): length in bytes for the type field of the TLV.
+        length_size (int): length in bytes for the length field of the TLV.
     """
-
     size_classes = {1: UBInt8,
                     2: UBInt16,
                     3: UBInt24,
@@ -592,12 +593,13 @@ def get_custom_tlv_class(type_size=3, length_size=1):
     custom_length = size_classes[length_size]
 
     class CustomTLV(GenericStruct):
-        """ a compact TLV class
+        """A compact TLV class.
 
         Args:
-            tlv_type: type field of the TLV
-            tlv_value: length field of the TLV
+            tlv_type: type field of the TLV.
+            tlv_value: length field of the TLV.
         """
+
         tlv_type = custom_type()
         tlv_length = custom_length()
         tlv_value = BinaryData()
@@ -617,13 +619,12 @@ def get_custom_tlv_class(type_size=3, length_size=1):
             return super()._pack()
 
         def unpack(self, buff, offset=0):
-            """Unpack the buffer into a custom TLV
+            """Unpack the buffer into a custom TLV.
 
             Args:
                 buff (bytes): The binary data to be unpacked.
                 offset (int): If we need to shift the beginning of the data.
             """
-
             begin = offset
             for name, value in list(self.get_class_attributes())[:-1]:
                 size = self._unpack_attribute(name, value, buff, begin)

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -94,13 +94,13 @@ class DPID(GenericType):
 
     _fmt = "!8B"
 
-    def __init__(self, dpid=None):
+    def __init__(self, value=None):
         """Create an instance and optionally set its dpid value.
 
         Args:
             dpid (str): String with DPID value(e.g. `00:00:00:00:00:00:00:01`).
         """
-        super().__init__(value=dpid)
+        super().__init__(value=value)
 
     def __str__(self):
         return self._value
@@ -154,6 +154,9 @@ class Char(GenericType):
         self.length = length
         self._fmt = '!{}{}'.format(self.length, 's')
 
+    def _get_new_instance(self, value):
+        return type(self)(value, length=self.length)
+
     def _pack(self):
         packed = struct.pack(self._fmt, bytes(self.value, 'ascii'))
         return packed[:-1] + b'\0'  # null-terminated
@@ -187,18 +190,18 @@ class IPAddress(GenericType):
     netmask = UBInt32()
     max_prefix = UBInt32(32)
 
-    def __init__(self, address="0.0.0.0/32"):
+    def __init__(self, value="0.0.0.0/32"):
         """The constructor takes the parameters below.
 
         Args:
             address (str): IP Address using ipv4. Defaults to '0.0.0.0/32'
         """
-        if address.find('/') >= 0:
-            address, netmask = address.split('/')
+        if value.find('/') >= 0:
+            value, netmask = value.split('/')
         else:
             netmask = 32
 
-        super().__init__(address)
+        super().__init__(value)
         self.netmask = int(netmask)
 
     def _pack(self):
@@ -238,16 +241,16 @@ class IPAddress(GenericType):
 class HWAddress(GenericType):
     """Defines a hardware address."""
 
-    def __init__(self, hw_address='00:00:00:00:00:00'):  # noqa
+    def __init__(self, value='00:00:00:00:00:00'):  # noqa
         """The constructor takes the parameters below.
 
         Args:
-            hw_address (bytes): Hardware address. Defaults to
+            value (bytes): Hardware address. Defaults to
                 '00:00:00:00:00:00'.
         """
-        if hw_address == 0:
-            hw_address = '00:00:00:00:00:00'
-        super().__init__(hw_address)
+        if value == 0:
+            value = '00:00:00:00:00:00'
+        super().__init__(value)
 
     def _pack(self):
         value = self._value.split(':')

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -353,7 +353,7 @@ class BinaryData(GenericType):
         return len(self._value)
 
 
-class TypeList(list, GenericStruct):
+class TypeList(GenericStruct, list):
     """Base class for lists that store objects of one single type."""
 
     def __init__(self, items):

--- a/pyof/v0x01/controller2switch/flow_mod.py
+++ b/pyof/v0x01/controller2switch/flow_mod.py
@@ -100,4 +100,4 @@ class FlowMod(GenericMessage):
         self.buffer_id = buffer_id
         self.out_port = out_port
         self.flags = flags
-        self.actions = [] if actions is None else actions
+        self.actions = ListOfActions() if actions is None else actions

--- a/pyof/v0x01/controller2switch/packet_out.py
+++ b/pyof/v0x01/controller2switch/packet_out.py
@@ -47,7 +47,7 @@ class PacketOut(GenericMessage):
         super().__init__(xid)
         self.buffer_id = buffer_id
         self.in_port = in_port
-        self.actions = [] if actions is None else actions
+        self.actions = ListOfActions() if actions is None else actions
         self.data = data
 
     def validate(self):

--- a/pyof/v0x04/asynchronous/packet_in.py
+++ b/pyof/v0x04/asynchronous/packet_in.py
@@ -82,4 +82,5 @@ class PacketIn(GenericMessage):
         self.table_id = table_id
         self.cookie = cookie
         self.match = match
+        self.pad = Pad(2)
         self.data = data

--- a/pyof/v0x04/common/flow_match.py
+++ b/pyof/v0x04/common/flow_match.py
@@ -184,6 +184,16 @@ class VlanId(IntEnum):
 
 # Classes
 
+class OxmType(GenericStruct):
+    oxm_class = UBInt16(enum_ref=OxmClass)
+    oxm_field = UBInt8()
+
+    def __init__(self, oxm_class, oxm_field):
+        cls = type(self)
+        self.oxm_class = type(cls.oxm_class)(oxm_class)
+        self.oxm_field = oxm_field
+
+
 class OxmTLV(GenericStruct):
 
     oxm_class = UBInt16(enum_ref=OxmClass)

--- a/pyof/v0x04/common/flow_match.py
+++ b/pyof/v0x04/common/flow_match.py
@@ -8,16 +8,14 @@ from enum import Enum, IntEnum
 
 # Local source tree imports
 from pyof.foundation.base import GenericStruct
-from pyof.foundation.basic_types import (FixedTypeList, UBInt8, UBInt16,
-                                         UBInt32, Pad, BinaryData,
-                                         CustomTLV_24_8)
-from pyof.foundation.exceptions import PackException
+from pyof.foundation.basic_types import (
+    BinaryData, CustomTLV_24_8, FixedTypeList, Pad, UBInt8, UBInt16, UBInt32)
 
 # Third-party imports
 
 
 __all__ = ('Ipv6ExtHdrFlags', 'Match', 'OxmOfbMatchField', 'MatchType',
-           'OxmExperimenterHeader', 'MatchField', 'VlanId')
+           'OxmExperimenterHeader', 'OxmMatchFields', 'VlanId')
 
 
 class Ipv6ExtHdrFlags(Enum):
@@ -185,7 +183,7 @@ class VlanId(IntEnum):
 # Classes
 
 class OxmType(GenericStruct):
-    """ Oxm TLV `type` metafield.
+    """Oxm TLV `type` metafield.
 
     OxmType is defined by the combination of a OxmClass and a OxmField,
 
@@ -194,17 +192,19 @@ class OxmType(GenericStruct):
         oxm_field (:class:`OxmOfbMatchField`, Oxm*MatchField, int): the oxm
         TLV defined field of the correspondent class
     """
+
     oxm_class = UBInt16(enum_ref=OxmClass)
     oxm_field = UBInt8()
 
     def __init__(self, oxm_class, oxm_field):
+        super().__init__()
         cls = type(self)
         self.oxm_class = type(cls.oxm_class)(oxm_class)
         self.oxm_field = oxm_field
 
 
 class OxmTLV(GenericStruct):
-    """ Oxm (Openflow Extensible Match) TLV.
+    """Oxm (Openflow Extensible Match) TLV.
 
     Args:
         oxm_class (:class:`OxmClass`, int): The oxm TLV defined class.
@@ -222,6 +222,7 @@ class OxmTLV(GenericStruct):
 
     def __init__(self, oxm_class=None, oxm_field=None,
                  oxm_hasmask=None, oxm_value=None):
+        super().__init__()
         self.oxm_class = oxm_class
         self.oxm_field = oxm_field
         self.oxm_hasmask = oxm_hasmask if oxm_hasmask else 0
@@ -255,7 +256,7 @@ class OxmTLV(GenericStruct):
 
         tlv_value = self.oxm_value
         tlv = self.tlv_class(tlv_type, tlv_value)
-        return tlv._pack()
+        return tlv._pack()   # noqa
 
     def _get_size(self):
         size = super()._get_size() - 1
@@ -327,6 +328,7 @@ class Match(GenericStruct):
         return super_size + (8 - (super_size % 8)) % 8
 
     def unpack(self, buff, offset=0):
+        """Unpack bytes buffer into this Instance."""
         begin = offset
         for name, value in list(self.get_class_attributes())[:-1]:
             size = self._unpack_attribute(name, value, buff, begin)

--- a/pyof/v0x04/common/flow_match.py
+++ b/pyof/v0x04/common/flow_match.py
@@ -8,14 +8,16 @@ from enum import Enum, IntEnum
 
 # Local source tree imports
 from pyof.foundation.base import GenericStruct
-from pyof.foundation.basic_types import FixedTypeList, UBInt8, UBInt16, UBInt32
+from pyof.foundation.basic_types import (FixedTypeList, UBInt8, UBInt16,
+                                         UBInt32, Pad, BinaryData,
+                                         CustomTLV_24_8)
+from pyof.foundation.exceptions import PackException
 
 # Third-party imports
 
 
-__all__ = ('Ipv6ExtHdrFlags', 'Match', 'MatchField', 'MatchType',
-           'OxmExperimenterHeader', 'OxmOfbMatchField', 'VlanId',
-           'ListOfOxmHeader')
+__all__ = ('Ipv6ExtHdrFlags', 'Match', 'OxmOfbMatchField', 'MatchType',
+           'OxmExperimenterHeader', 'MatchField', 'VlanId')
 
 
 class Ipv6ExtHdrFlags(Enum):
@@ -41,7 +43,7 @@ class Ipv6ExtHdrFlags(Enum):
     OFPIEH_UNSEQ = 1 << 8
 
 
-class MatchField(IntEnum):
+class OxmOfbMatchField(IntEnum):
     """OXM Flow match field types for OpenFlow basic class.
 
     A switch is not required to support all match field types, just those
@@ -148,7 +150,7 @@ class MatchType(IntEnum):
     OFPMT_OXM = 1
 
 
-class OxmOfbMatchField(IntEnum):
+class OxmClass(IntEnum):
     """OpenFlow Extensible Match (OXM) Class IDs.
 
     The high order bit differentiate reserved classes from member classes.
@@ -182,17 +184,66 @@ class VlanId(IntEnum):
 
 # Classes
 
+class OxmTLV(GenericStruct):
 
-class OxmHeader(GenericStruct):
+    oxm_class = UBInt16(enum_ref=OxmClass)
+    oxm_field = UBInt8()
+    oxm_hasmask = UBInt8()
+    oxm_length = UBInt8()
+    oxm_value = BinaryData()
+
+    def __init__(self, oxm_class=None, oxm_field=None,
+                 oxm_hasmask=None, oxm_value=None):
+        self.oxm_class = oxm_class
+        self.oxm_field = oxm_field
+        self.oxm_hasmask = oxm_hasmask if oxm_hasmask else 0
+        self.oxm_length = None
+        self.oxm_value = oxm_value
+        self.tlv_class = CustomTLV_24_8
+
+    def unpack(self, buff, offset=0):
+        tlv = self.tlv_class()
+        tlv.unpack(buff, offset)
+        # print('tlv unpack values:')
+        # print(type(tlv.tlv_type), tlv.tlv_type)
+        # print(type(tlv.tlv_length), tlv.tlv_length)
+        # print(type(tlv.tlv_value), tlv.tlv_value)
+        self.oxm_class = tlv.tlv_type >> 8
+        self.oxm_field = (tlv.tlv_type & 0xFF) >> 1
+        self.oxm_hasmask = tlv.tlv_type & 1
+        self.oxm_length = tlv.tlv_length
+        self.oxm_value = tlv.tlv_value
+
+    def _pack(self):
+        tlv_type = ((self.oxm_class << 8) +
+                    (self.oxm_field << 1) +
+                    self.oxm_hasmask)
+
+        tlv_value = self.oxm_value
+        tlv = self.tlv_class(tlv_type, tlv_value)
+        return tlv._pack()
+
+    def _get_size(self):
+        size = super()._get_size() - 1
+        return size
+
+
+class OxmMatchFields(FixedTypeList):
     """Generic Openflow EXtensible Match header.
 
     Abstract class that can be instanciated as Match or OxmExperimenterHeader.
     """
 
-    pass
+    def __init__(self, items=None):
+        """The constructor just assings parameters to object attributes.
+
+        Args:
+            items (OxmHeader): Instance or a list of instances.
+        """
+        super().__init__(pyof_class=OxmTLV, items=items)
 
 
-class Match(OxmHeader):
+class Match(GenericStruct):
     """Describes the flow match header structure.
 
     These are the fields to match against flows.
@@ -207,13 +258,9 @@ class Match(OxmHeader):
     match_type = UBInt16(enum_ref=MatchType)
     #: Length of Match (excluding padding)
     length = UBInt16()
-    oxm_field1 = UBInt8(enum_ref=OxmOfbMatchField)
-    oxm_field2 = UBInt8(enum_ref=OxmOfbMatchField)
-    oxm_field3 = UBInt8(enum_ref=OxmOfbMatchField)
-    oxm_field4 = UBInt8(enum_ref=OxmOfbMatchField)
+    oxm_match_fields = OxmMatchFields()
 
-    def __init__(self, match_type=None, length=None, oxm_field1=None,
-                 oxm_field2=None, oxm_field3=None, oxm_field4=None):
+    def __init__(self, match_type=None, oxm_match_fields=None):
         """Describe the flow match header structure.
 
         Args:
@@ -222,26 +269,45 @@ class Match(OxmHeader):
                           Exactly (length - 4) (possibly 0) bytes containing
                           OXM TLVs, then exactly ((length + 7)/8*8 - length)
                           (between 0 and 7) bytes of all-zero bytes.
-            oxm_field1 (OXMClass): Sample description.
-            oxm_field2 (OXMClass): Sample description.
-            oxm_field3 (OXMClass): Sample description.
-            oxm_field4 (OXMClass): Sample description.
+            oxm_fields (OxmMatchFields): Sample description.
         """
         super().__init__()
         self.match_type = match_type
-        self.length = length
-        self.oxm_field1 = oxm_field1
-        self.oxm_field2 = oxm_field2
-        self.oxm_field3 = oxm_field3
-        self.oxm_field4 = oxm_field4
+        self.oxm_match_fields = oxm_match_fields
+        self._update_match_length()
+
+    def _update_match_length(self):
+        self.length = super()._get_size()
+
+    def _pack(self):
+        self._update_match_length()
+        packet = super()._pack()
+        super_size = len(packet)
+        lacking_bytes = (8 - (super_size % 8)) % 8
+        if lacking_bytes != 0:
+            packet += Pad(lacking_bytes).pack()
+        return packet
+
+    def _get_size(self):
+        super_size = super()._get_size()
+        return super_size + (8 - (super_size % 8)) % 8
+
+    def unpack(self, buff, offset=0):
+        begin = offset
+        for name, value in list(self.get_class_attributes())[:-1]:
+            size = self._unpack_attribute(name, value, buff, begin)
+            begin += size
+        self._unpack_attribute('oxm_match_fields', type(self).oxm_match_fields,
+                               buff[:offset + self.length],
+                               begin)
 
 
-class OxmExperimenterHeader(OxmHeader):
+class OxmExperimenterHeader(GenericStruct):
     """Header for OXM experimenter match fields."""
 
     #: oxm_class = OFPXMC_EXPERIMENTER
-    oxm_header = UBInt32(OxmOfbMatchField.OFPXMC_EXPERIMENTER,
-                         enum_ref=OxmOfbMatchField)
+    oxm_header = UBInt32(OxmClass.OFPXMC_EXPERIMENTER,
+                         enum_ref=OxmClass)
     #: Experimenter ID which takes the same form as in struct
     #:     ofp_experimenter_header
     experimenter = UBInt32()
@@ -269,4 +335,4 @@ class ListOfOxmHeader(FixedTypeList):
         Args:
             items (OxmHeader): Instance or a list of instances.
         """
-        super().__init__(pyof_class=OxmHeader, items=items)
+        super().__init__(pyof_class=OxmTLV, items=items)

--- a/pyof/v0x04/common/flow_match.py
+++ b/pyof/v0x04/common/flow_match.py
@@ -185,6 +185,15 @@ class VlanId(IntEnum):
 # Classes
 
 class OxmType(GenericStruct):
+    """ Oxm TLV `type` metafield.
+
+    OxmType is defined by the combination of a OxmClass and a OxmField,
+
+    Args:
+        oxm_class (:class:`OxmClass`, int): The oxm TLV defined class.
+        oxm_field (:class:`OxmOfbMatchField`, Oxm*MatchField, int): the oxm
+        TLV defined field of the correspondent class
+    """
     oxm_class = UBInt16(enum_ref=OxmClass)
     oxm_field = UBInt8()
 
@@ -195,6 +204,15 @@ class OxmType(GenericStruct):
 
 
 class OxmTLV(GenericStruct):
+    """ Oxm (Openflow Extensible Match) TLV.
+
+    Args:
+        oxm_class (:class:`OxmClass`, int): The oxm TLV defined class.
+        oxm_field (:class:`OxmOfbMatchField`, Oxm*MatchField, int): the oxm
+            TLV defined field of the correspondent oxm_class.
+        oxm_hasmask (bool):
+        oxm_value (:class:`BinaryData`, bytes):
+    """
 
     oxm_class = UBInt16(enum_ref=OxmClass)
     oxm_field = UBInt8()
@@ -212,6 +230,12 @@ class OxmTLV(GenericStruct):
         self.tlv_class = CustomTLV_24_8
 
     def unpack(self, buff, offset=0):
+        """Unpack the buffer into a OxmTLV.
+
+        Args:
+            buff (bytes): The binary data to be unpacked.
+            offset (int): If we need to shift the beginning of the data.
+        """
         tlv = self.tlv_class()
         tlv.unpack(buff, offset)
         # print('tlv unpack values:')

--- a/pyof/v0x04/common/flow_match.py
+++ b/pyof/v0x04/common/flow_match.py
@@ -222,6 +222,14 @@ class OxmTLV(GenericStruct):
 
     def __init__(self, oxm_class=None, oxm_field=None,
                  oxm_hasmask=None, oxm_value=None):
+        """Init OxmTLV with oxm class, field and value.
+
+        Args:
+            oxm_class (OxmClass): The oxm_class field.
+            oxm_field (int): The oxm_field field.
+            oxm_hasmask (int): The oxm_hasmask field.
+            oxm_value (int/bytes): The oxm_value field.
+        """
         super().__init__()
         self.oxm_class = oxm_class
         self.oxm_field = oxm_field

--- a/pyof/v0x04/common/flow_match.py
+++ b/pyof/v0x04/common/flow_match.py
@@ -15,7 +15,7 @@ from pyof.foundation.basic_types import (
 
 
 __all__ = ('Ipv6ExtHdrFlags', 'Match', 'OxmOfbMatchField', 'MatchType',
-           'OxmExperimenterHeader', 'OxmMatchFields', 'VlanId')
+           'OxmExperimenterHeader', 'OxmMatchFields', 'VlanId', 'OxmTLV')
 
 
 class Ipv6ExtHdrFlags(Enum):

--- a/pyof/v0x04/controller2switch/packet_out.py
+++ b/pyof/v0x04/controller2switch/packet_out.py
@@ -71,17 +71,9 @@ class PacketOut(GenericMessage):
         except ValidationError:
             return False
 
-    def pack(self, value=None):
-        """Update the action_len attribute and call super's pack."""
-        if value is None:
+    def _pack(self, value=None):
             self._update_actions_len()
-            return super().pack()
-        elif isinstance(value, type(self)):
-            return value.pack()
-        else:
-            msg = "{} is not an instance of {}".format(value,
-                                                       type(self).__name__)
-            raise PackException(msg)
+            return super()._pack()
 
     def unpack(self, buff, offset=0):
         """Unpack a binary message into this object's attributes.

--- a/pyof/v0x04/controller2switch/packet_out.py
+++ b/pyof/v0x04/controller2switch/packet_out.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 from pyof.foundation.base import GenericMessage
 from pyof.foundation.basic_types import BinaryData, Pad, UBInt16, UBInt32
-from pyof.foundation.exceptions import PackException, ValidationError
+from pyof.foundation.exceptions import ValidationError
 from pyof.v0x04.common.action import ListOfActions
 from pyof.v0x04.common.header import Header, Type
 from pyof.v0x04.common.port import Port, PortNo
@@ -72,8 +72,8 @@ class PacketOut(GenericMessage):
             return False
 
     def _pack(self, value=None):
-            self._update_actions_len()
-            return super()._pack()
+        self._update_actions_len()
+        return super()._pack()
 
     def unpack(self, buff, offset=0):
         """Unpack a binary message into this object's attributes.
@@ -97,7 +97,7 @@ class PacketOut(GenericMessage):
                 attribute = deepcopy(class_attribute)
                 if attribute_name == 'actions':
                     length = self.actions_len.value
-                    attribute.unpack(buff[begin:begin+length])
+                    attribute.unpack(buff[begin:begin + length])
                 else:
                     attribute.unpack(buff, begin)
                 setattr(self, attribute_name, attribute)

--- a/tests/v0x01/test_controller2switch/test_stats_reply.py
+++ b/tests/v0x01/test_controller2switch/test_stats_reply.py
@@ -14,5 +14,5 @@ class TestStatsReply(TestStruct):
         super().set_raw_dump_file('v0x01', 'ofpt_stats_reply')
         super().set_raw_dump_object(StatsReply, xid=1,
                                     body_type=StatsTypes.OFPST_FLOW,
-                                    flags=0x0001, body=[])
+                                    flags=0x0001, body=b'')
         super().set_minimum_size(12)

--- a/tests/v0x01/test_controller2switch/test_stats_request.py
+++ b/tests/v0x01/test_controller2switch/test_stats_request.py
@@ -14,5 +14,5 @@ class TestStatsRequest(TestStruct):
         super().set_raw_dump_file('v0x01', 'ofpt_stats_request')
         super().set_raw_dump_object(StatsRequest, xid=1,
                                     body_type=StatsTypes.OFPST_FLOW,
-                                    flags=1, body=[])
+                                    flags=1, body=b'')
         super().set_minimum_size(12)

--- a/tests/v0x04/test_controller2switch/test_multipart_reply.py
+++ b/tests/v0x04/test_controller2switch/test_multipart_reply.py
@@ -16,13 +16,13 @@ class TestMultipartReply(TestStruct):
         super().set_message(MultipartReply, xid=16,
                             multipart_type=MultipartTypes.OFPMP_METER_CONFIG,
                             flags=MultipartReplyFlags.OFPMPF_REPLY_MORE,
-                            body='')
+                            body=b'')
         super().set_minimum_size(16)
 
     @staticmethod
     def get_attributes(multipart_type=MultipartTypes.OFPMP_DESC,
                        flags=MultipartReplyFlags.OFPMPF_REPLY_MORE,
-                       body=''):
+                       body=b''):
         """Method used to return a dict with instance paramenters."""
         return {'xid': 32, 'multipart_type': multipart_type, 'flags': flags,
                 'body': body}

--- a/tests/v0x04/test_controller2switch/test_multipart_request.py
+++ b/tests/v0x04/test_controller2switch/test_multipart_request.py
@@ -22,7 +22,7 @@ class TestMultipartRequest(TestStruct):
     @staticmethod
     def get_attributes(multipart_type=MultipartTypes.OFPMP_DESC,
                        flags=MultipartRequestFlags.OFPMPF_REQ_MORE,
-                       body=''):
+                       body=b''):
         """Method used to return a dict with instance paramenters."""
         return {'xid': 32, 'multipart_type': multipart_type, 'flags': flags,
                 'body': body}


### PR DESCRIPTION
This relates to https://github.com/kytos/python-openflow/issues/348.
It implements ``Match``, ``MatchFields``, ``OxmTLV`` and ``CustomTLV`` classes for use in ``PACKETIN``s.
The other structures affected in the issue (like ``ActionSetField`` for example) have not yet been treated. [UPDATE: I have included a commit to fix ActionSetField]

I'll still organize the commits, remove comments, update the docstrings, and organize a few tests I've made to include in the testing suite.
Please for now include comments in the PR comments tread since these commits will probably be overwritten by amended ones.

This was tested unpacking a packet-in described in the email reporting a packet-in unpack exception:

——————— Packet In ————————— —
Transmission Control Protocol, Src Port: 55566, Dst Port: 6633, Seq:
172, Ack: 25, Len: 123
OpenFlow 1.3
    Version: 1.3 (0x04)
    Type: OFPT_PACKET_IN (10)
    Length: 123
    Transaction ID: 0
    Buffer ID: 257
    Total length: 81
    Reason: OFPR_ACTION (1)
    Table ID: 0
    Cookie: 0xffffffffffffffff
    Match
        Type: OFPMT_OXM (1)
        Length: 12
        OXM field
            Class: OFPXMC_OPENFLOW_BASIC (0x8000)
            0000 000. = Field: OFPXMT_OFB_IN_PORT (0)
            .... ...0 = Has mask: False
            Length: 4
            Value: 22
        Pad: 00000000
    Pad: 0000
    Data