### PR TITLE
Fix MultipartReply unpacking

### DIFF
--- a/pyof/v0x04/controller2switch/multipart_reply.py
+++ b/pyof/v0x04/controller2switch/multipart_reply.py
@@ -63,7 +63,7 @@ class MultipartReply(GenericMessage):
     #: One of the OFPMP_* constants.
     multipart_type = UBInt16(enum_ref=MultipartTypes)
     #: OFPMPF_REPLY_* flags.
-    flags = UBInt16(enum_ref=MultipartReplyFlags)
+    flags = UBInt16()
     #: Padding
     pad = Pad(4)
     #: Body of the reply
@@ -165,7 +165,7 @@ class MultipartReply(GenericMessage):
 
         array_of_class = array_of_bodies.get(self.multipart_type, None)
         if array_of_class:
-            return FixedTypeList(pyof_class=pyof_class)
+            return FixedTypeList(pyof_class=array_of_class)
 
         return BinaryData(b'')
 


### PR DESCRIPTION
Fix #463

Remove an unnecessary enum_ref, return the correct type for list bodies.