### PR TITLE
Add attribute name to PackException message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ UNRELEASED - Under development
 ******************************
 Added
 =====
+- Attribute name in PackException message.
 
 Changed
 =======

--- a/pyof/foundation/exceptions.py
+++ b/pyof/foundation/exceptions.py
@@ -57,5 +57,4 @@ class UnpackException(Exception):
 class PackException(Exception):
     """Error while unpacking."""
 
-    def __str__(self):
-        return "Pack error: " + super().__str__()
+    pass


### PR DESCRIPTION
Currently, the user doesn't know the name of attribute containing the wrong value:
```python
from pyof.v0x04.controller2switch.flow_mod import FlowMod
FlowMod().pack()
# Current message:
# PackException: Pack error: UBInt8 could not pack NoneType = None.
# This PR's message:
# PackException: FlowMod.command - Expected UBInt8, found value "None" of type NoneType
```