### PR TITLE
Fixing OFPT_GET_CONFIG_REPLY message type

### DIFF
--- a/pyof/v0x01/controller2switch/get_config_reply.py
+++ b/pyof/v0x01/controller2switch/get_config_reply.py
@@ -24,4 +24,4 @@ class GetConfigReply(SwitchConfig):
                 datapath should send to the controller.
         """
         super().__init__(xid, flags, miss_send_len)
-        self.header.message_type = Type.OFPT_SET_CONFIG
+        self.header.message_type = Type.OFPT_GET_CONFIG_REPLY


### PR DESCRIPTION
OFPT_GET_CONFIG_REPLY messages have the wrong message_type where instead of receiving Type.OFPT_GET_CONFIG_REPLY it was getting Type.OFPT_SET_CONFIG.