### PR TITLE
Added support for OpenFlow 1.3 OFP_ERROR codes with the get_class method

### DIFF
--- a/pyof/v0x04/asynchronous/error_msg.py
+++ b/pyof/v0x04/asynchronous/error_msg.py
@@ -197,6 +197,29 @@ class ErrorType(IntEnum):
     #: Experimenter error messages.
     OFPET_EXPERIMENTER = 0xffff
 
+    def get_class(self):
+        """Return a Code class based on current ErrorType value.
+
+        Returns:
+            enum.IntEnum: class referenced by current error type.
+
+        """
+        classes = {'OFPET_HELLO_FAILED': HelloFailedCode,
+                   'OFPET_BAD_REQUEST': BadRequestCode,
+                   'OFPET_BAD_ACTION': BadActionCode,
+                   'OFPET_BAD_INSTRUCTION': BadInstructionCode,
+                   'OFPET_BAD_MATCH': BadMatchCode,
+                   'OFPET_FLOW_MOD_FAILED': FlowModFailedCode,
+                   'OFPET_GROUP_MOD_FAILED': GroupModFailedCode,
+                   'OFPET_PORT_MOD_FAILED': PortModFailedCode,
+                   'OFPET_QUEUE_OP_FAILED': QueueOpFailedCode,
+                   'OFPET_SWITCH_CONFIG_FAILED': SwitchConfigFailedCode,
+                   'OFPET_ROLE_REQUEST_FAILED': RoleRequestFailedCode,
+                   'OFPET_METER_MOD_FAILED': MeterModFailedCode,
+                   'OFPET_TABLE_MOD_FAILED': TableModFailedCode,
+                   'OFPET_TABLE_FEATURES_FAILED': TableFeaturesFailedCode}
+        return classes[self.name]
+
 
 class FlowModFailedCode(IntEnum):
     """Error_msg 'code' values for OFPET_FLOW_MOD_FAILED.


### PR DESCRIPTION
This PR adds support for proper handling of OFP_ERROR messages, without this, any OpenFlow1.3 OFP_ERROR messages resulted in restarting the OpenFlow connection with the switches (this was impacting the deployment at ESnet):

Example: (this is when I flow that I was pushing resulted in OFP_ERROR) 

```
2018-10-21 13:07:50,793 - DEBUG [controller:controller.py:387] (MainThread) looking for listeners for kytos/core.openflow.raw.in
2018-10-21 13:07:50,794 - DEBUG [controller:controller.py:410] (MainThread) Raw Event handler called
2018-10-21 13:07:50,794 - DEBUG [kytos/of_core:main.py:200] (Thread-79) Connection ('ESnet_switch', 47144): New Raw Openflow packet - 0401004cc4d8070000040007040e0078c4d80700000000000000000000000000000000
000000000000000fa0ffffffffffffffffffffffff0001000000010012800000040000000a80000c02
2018-10-21 13:07:50,795 - DEBUG [kytos/of_core:main.py:223] (Thread-79) 'ErrorType' object has no attribute 'get_class'
2018-10-21 13:07:50,796 - DEBUG [kytos/of_core:main.py:226] (Thread-79) Connection ('ESnet_switch', 47144): connection closed before version negotiation
```
Here's the connection being dropped:

```
2018-10-21 13:07:50,796 - DEBUG [kytos/of_core:main.py:226] (Thread-79) Connection ('ESnet_switch', 47144): connection closed before version negotiation
2018-10-21 13:07:50,796 - DEBUG [kytos.core.connection:connection.py:73] (Thread-79) Connection ('ESnet_switch', 47144) changed state: ConnectionState.FINISHED
2018-10-21 13:07:50,796 - DEBUG [kytos.core.connection:connection.py:104] (Thread-79) Shutting down Connection ('ESnet_switch', 47144)
2018-10-21 13:07:50,796 - ERROR [asyncio:base_events.py:1266] (MainThread) Fatal read error on socket transport
protocol: <kytos.core.atcp_server.KytosServerProtocol object at 0x7f632c0e4a20>
transport: <_SelectorSocketTransport fd=19 read=polling write=<idle, bufsize=0>>
Traceback (most recent call last):
  File "/usr/lib64/python3.6/asyncio/selector_events.py", line 723, in _read_ready
    data = self._sock.recv(self.max_size)
OSError: [Errno 9] Bad file descriptor
2018-10-21 13:07:50,796 - DEBUG [kytos.core.connection:connection.py:110] (Thread-79) Connection Closed: ('ESnet_switch', 47144)
```

