### PR TITLE
pytest as the default test tool

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test=pytest
+
 [pycodestyle]
 exclude = .eggs,ENV,build,docs/conf.py,venv
 

--- a/setup.py
+++ b/setup.py
@@ -118,14 +118,9 @@ setup(name='python-openflow',
       license='MIT',
       test_suite='tests',
       include_package_data=True,
-      extras_require={
-          'dev': [
-              'coverage',
-              'tox',
-              'pip-tools',
-              'yala',
-          ],
-      },
+      setup_requires=['pytest-runner'],
+      tests_require=['coverage', 'pytest', 'yala', 'tox'],
+      extras_require={'dev': ['pip-tools >= 2.0']},
       packages=find_packages(exclude=['tests']),
       cmdclass={
           'ci': CITest,

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -50,7 +50,7 @@ class TestStruct(unittest.TestCase):
         # Override the run method, so it does nothing instead of running the
         # tests (again).
         if self.__class__ == TestStruct:
-            self.run = lambda self, *args, **kwargs: None
+            self.run = lambda *args, **kwargs: None
 
     _new_raw_dump = None
     _new_raw_object = None

--- a/tests/v0x04/test_struct.py
+++ b/tests/v0x04/test_struct.py
@@ -50,7 +50,7 @@ class TestStruct(unittest.TestCase):
         # Override the run method, so it does nothing instead of running the
         # tests (again).
         if self.__class__ == TestStruct:
-            self.run = lambda self, *args, **kwargs: None
+            self.run = lambda *args, **kwargs: None
 
     _msg_cls = None
     _msg_params = None


### PR DESCRIPTION
The output is a little different - it counts `skipped` and `expected failures` as `passed`, but it seems OK.

unittest:
```
Pack, unpack the result and assert the values are equal. ... ok
test_max_field_value (tests.v0x04.test_common.test_flow_match.TestOxmTLV)
Use all bits of oxm_field. ... ok
test_pack_invalid_field (tests.v0x04.test_common.test_flow_match.TestOxmTLV)
Raise PackException if field is invalid for a class. ... ok
test_pack_overflowed_field (tests.v0x04.test_common.test_flow_match.TestOxmTLV)
Raise PackException if field is bigger than 7 bit. ... ok
test_unpack_invalid_field (tests.v0x04.test_common.test_flow_match.TestOxmTLV)
Raise UnpackException if field is invalid for a class. ... ok
----------------------------------------------------------------------
Ran 268 tests in 0.135s

OK (skipped=67, expected failures=2)
```

pytest:
```
tests/v0x04/test_controller2switch/test_set_async.py ...s                [ 94%]
tests/v0x04/test_controller2switch/test_table_mod.py ..                  [ 95%]
tests/v0x04/test_controller2switch/test_table_stats.py ...s              [ 96%]
tests/v0x04/test_symmetric/test_echo_reply.py ...s                       [ 97%]
tests/v0x04/test_symmetric/test_echo_request.py ...s                     [ 98%]
tests/v0x04/test_symmetric/test_hello.py ...s                            [ 99%]
tests/v0x04/test_symmetric/test_vendor_header.py ...s                    [100%]

============== 333 passed, 67 skipped, 2 xfailed in 2.28 seconds ===============
```
As with Kytos core, I've made the minimal changes possible to run with pytest, without converting everything to the pytest syntax (yet).