### PR TITLE
Added long description field for display in pypi.org (PyPI)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ class Linter(SimpleCommand):
 setup(name='python-openflow',
       version=__version__,
       description='Library to parse and generate OpenFlow messages',
+      long_description=open("README.rst", "r").read(),
       url='http://github.com/kytos/python-openflow',
       author='Kytos Team',
       author_email='devel@lists.kytos.io',


### PR DESCRIPTION
Today, the package hosted in PyPI doesn't have a long description,
this commit adds the long_description field by reading the README.rst file.