### PR TITLE
Merge pull request #590 from gleybersonandrade/fix-coverage

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,7 +6,7 @@ filter:
     paths: ["pyof/*", "tests/*"]
 build:
     environment:
-        python: 3.6.0
+        python: 3.6.3
         postgresql: false
         redis: false
     dependencies:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ certifi==2017.7.27.1      # via requests
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
 colorama==0.3.9           # via radon
-coverage==4.4.1
+coverage==5.0.3
 docutils==0.14            # via sphinx
 flake8-polyfill==1.0.1    # via radon
 flake8==3.4.1             # via flake8-polyfill


### PR DESCRIPTION
The coverage version of requirements and python version of scrutinizer.yml was creating an error when running Scrutinizer. This commit changes coverage version from 4.5.1 to 5.0.3 and update python version from 3.6.0 to 3.6.3.