### PR TITLE
Allow minimum-size test to never skip

### DIFF
--- a/tests/unit/test_struct.py
+++ b/tests/unit/test_struct.py
@@ -178,5 +178,5 @@ class TestStruct(unittest.TestCase):
         """Test struct minimum size."""
         obj = TestStruct._msg_cls()
         if self._min_size is None:
-            self._min_size = obj.get_size()
+            raise Exception(f'{self.__class__.__name__}._min_size is not set')
         self.assertEqual(obj.get_size(), self._min_size)

--- a/tests/unit/test_struct.py
+++ b/tests/unit/test_struct.py
@@ -176,7 +176,7 @@ class TestStruct(unittest.TestCase):
 
     def test_minimum_size(self):
         """Test struct minimum size."""
-        if self._min_size is None:
-            raise self.skipTest('minimum size was not set.')
         obj = TestStruct._msg_cls()
+        if self._min_size is None:
+            self._min_size = obj.get_size()
         self.assertEqual(obj.get_size(), self._min_size)

--- a/tests/unit/v0x01/test_controller2switch/test_flow_mod.py
+++ b/tests/unit/v0x01/test_controller2switch/test_flow_mod.py
@@ -29,7 +29,7 @@ class TestFlowDelete(TestStruct):
         super().set_raw_dump_file('v0x01', 'ofpt_flow_delete')
         kwargs = _get_flowmod_kwargs(FlowModCommand.OFPFC_DELETE)
         super().set_raw_dump_object(FlowMod, **kwargs)
-        # No need to test minimum size again.
+        super().set_minimum_size(72)
 
 
 def _get_flowmod_kwargs(command):

--- a/tests/unit/v0x01/test_symmetric/test_vendor_header.py
+++ b/tests/unit/v0x01/test_symmetric/test_vendor_header.py
@@ -6,6 +6,10 @@ from tests.unit.test_struct import TestStruct
 class TestVendorHeader(TestStruct):
     """Vendor message tests (also those in :class:`.TestDump`)."""
 
+    @classmethod
+    def setUpClass(cls):
+        super().set_minimum_size(8)
+
     def test_unpack(self):
         """Test unpack VendorHeader message."""
         message = b'My custom vendor extra data.'


### PR DESCRIPTION
The Capstone 1 team at FIU attempted to solve easy issue #434  for our Senior Project class. This may not be a probable solution, since it feels like the test results for the 2 skipped tests may be inaccurate; however, we tested it in our environment and it is working in some way.

![image](https://user-images.githubusercontent.com/42590607/84702823-3bca8400-af25-11ea-8ba6-0f774cfa49f5.jpeg)