### PR TITLE
Add IPv6 address class

### DIFF
--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -377,6 +377,7 @@ class IPV6Address(GenericType):
             index = temp.index('')
             temp = [x for x in temp if x != '']
             address = temp[:index] + ['0'] * (8 - len(temp)) + temp[index:]
+            address = ':'.join(address)
 
         super().__init__(address)
         self.netmask = int(netmask)

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -362,7 +362,7 @@ class IPv6Address(GenericType):
         """Create an IPv6Address with the parameters below.
 
         Args:
-            address (str): IP Address using ipv6.
+            address (str): IP Address using IPv6.
             Defaults to '0000:0000:0000:0000:0000:0000:0000:0000/128'
         """
         if '/' in address:

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -359,7 +359,7 @@ class IPv6Address(GenericType):
 
     def __init__(self, address="0000:0000:0000:0000:0000:0000:0000:0000/128",
                  netmask=None):
-        """Create an IPV6Address with the parameters below.
+        """Create an IPv6Address with the parameters below.
 
         Args:
             address (str): IP Address using ipv6.

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -374,27 +374,9 @@ class IPV6Address(GenericType):
             address = '0:0:0:0:0:0:0:0'
         elif '::' in address:
             temp = address.split(':')
-            temp = [x for x in temp if x]
-            num_pad = 8 - len(temp)
-
-            start = address.find('::')
-            if start == 0:
-                address_temp = address[1:]
-            elif start + 1 == len(address) - 1:
-                address_temp = address[:-1]
-                start += 1
-            else:
-                address_temp = address
-                start += 1
-
-            final_address = address_temp[:start]
-            for i in range(num_pad):
-                if i + 1 == num_pad:
-                    final_address += '0'
-                else:
-                    final_address += '0:'
-            final_address += address_temp[start:]
-            address = final_address
+            index = temp.index('')
+            temp = [x for x in temp if x != '']
+            address = temp[:index] + ['0'] * (8 - len(temp)) + temp[index:]
 
         super().__init__(address)
         self.netmask = int(netmask)

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -388,7 +388,7 @@ class IPv6Address(GenericType):
         If the value is None the self._value will be used to pack.
 
         Args:
-            value (str): IP Address with ipv6 format.
+            value (str): IP Address with IPv6 format.
 
         Returns:
             bytes: The binary representation.
@@ -410,7 +410,7 @@ class IPv6Address(GenericType):
             value = value.split(':')
             return struct.pack('!8H', *[int(x, 16) for x in value])
         except struct.error as err:
-            msg = "IPV6Address error. "
+            msg = "IPv6Address error. "
             msg += "Class: {}, struct error: {} ".format(type(value).__name__,
                                                          err)
             raise exceptions.PackException(msg)
@@ -442,7 +442,7 @@ class IPv6Address(GenericType):
         self._value = transformed_data
 
     def get_size(self, value=None):
-        """Return the ipv6 address size in bytes.
+        """Return the IPv6 address size in bytes.
 
         Args:
             value: In structs, the user can assign other value instead of
@@ -457,7 +457,7 @@ class IPv6Address(GenericType):
 
     def __deepcopy__(self, memo):
         """Improve deepcopy speed."""
-        return IPV6Address(address=self._value, netmask=self.netmask)
+        return IPv6Address(address=self._value, netmask=self.netmask)
 
 
 class HWAddress(GenericType):

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -118,7 +118,7 @@ class UBInt64(GenericType):
 class UBInt128(GenericType):
     """Format character for an Unsigned Long Long.
 
-    Class for an 64-bit (8-byte) Unsigned Integer.
+    Class for an 128-bit (16-byte) Unsigned Integer.
     """
 
     _fmt = "!8H"

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -352,8 +352,8 @@ class IPAddress(GenericType):
         return IPAddress(address=self._value, netmask=self.netmask)
 
 
-class IPV6Address(GenericType):
-    """Defines a IPV6 address."""
+class IPv6Address(GenericType):
+    """Defines a IPv6 address."""
 
     netmask = UBInt128()
 

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -412,7 +412,7 @@ class IPV6Address(GenericType):
 
         Raises:
             struct.error: If the value does not fit the binary format.
-            
+
         """
         if isinstance(value, type(self)):
             return value.pack()
@@ -431,7 +431,7 @@ class IPV6Address(GenericType):
             msg += "Class: {}, struct error: {} ".format(type(value).__name__,
                                                          err)
             raise exceptions.PackException(msg)
-    
+
     def unpack(self, buff, offset=0):
         """Unpack a binary message into this object's attributes.
 
@@ -448,16 +448,16 @@ class IPV6Address(GenericType):
         """
         def _int2hex(number):
             return "{0:0{1}x}".format(number, 4)
-        
+
         try:
             unpacked_data = struct.unpack('!8H', buff[offset:offset+16])
         except struct.error as exception:
             raise exceptions.UnpackException('%s; %s: %s' % (exception,
                                                              offset, buff))
-        
+
         transformed_data = ':'.join([_int2hex(x) for x in unpacked_data])
         self._value = transformed_data
-    
+
     def get_size(self, value=None):
         """Return the ipv6 address size in bytes.
 
@@ -471,7 +471,7 @@ class IPV6Address(GenericType):
 
         """
         return 16
-    
+
     def __deepcopy__(self, memo):
         """Improve deepcopy speed."""
         return IPV6Address(address=self._value, netmask=self.netmask)

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -115,6 +115,15 @@ class UBInt64(GenericType):
     _fmt = "!Q"
 
 
+class UBInt128(GenericType):
+    """Format character for an Unsigned Long Long.
+
+    Class for an 64-bit (8-byte) Unsigned Integer.
+    """
+
+    _fmt = "!8H"
+
+
 class DPID(GenericType):
     """DataPath ID. Identifies a switch."""
 
@@ -341,6 +350,131 @@ class IPAddress(GenericType):
     def __deepcopy__(self, memo):
         """Improve deepcopy speed."""
         return IPAddress(address=self._value, netmask=self.netmask)
+
+
+class IPV6Address(GenericType):
+    """Defines a IPV6 address."""
+
+    netmask = UBInt128()
+
+    def __init__(self, address="0000:0000:0000:0000:0000:0000:0000:0000/128",
+                 netmask=None):
+        """Create an IPV6Address with the parameters below.
+
+        Args:
+            address (str): IP Address using ipv6.
+            Defaults to '0000:0000:0000:0000:0000:0000:0000:0000/128'
+        """
+        if '/' in address:
+            address, netmask = address.split('/')
+        else:
+            netmask = 128 if netmask is None else netmask
+
+        if address == '::':
+            address = '0:0:0:0:0:0:0:0'
+        elif '::' in address:
+            temp = address.split(':')
+            temp = [x for x in temp if x]
+            num_pad = 8 - len(temp)
+
+            start = address.find('::')
+            if start == 0:
+                address_temp = address[1:]
+            elif start + 1 == len(address) - 1:
+                address_temp = address[:-1]
+                start += 1
+            else:
+                address_temp = address
+                start += 1
+
+            final_address = address_temp[:start]
+            for i in range(num_pad):
+                if i + 1 == num_pad:
+                    final_address += '0'
+                else:
+                    final_address += '0:'
+            final_address += address_temp[start:]
+            address = final_address
+
+        super().__init__(address)
+        self.netmask = int(netmask)
+
+    def pack(self, value=None):
+        """Pack the value as a binary representation.
+
+        If the value is None the self._value will be used to pack.
+
+        Args:
+            value (str): IP Address with ipv6 format.
+
+        Returns:
+            bytes: The binary representation.
+
+        Raises:
+            struct.error: If the value does not fit the binary format.
+            
+        """
+        if isinstance(value, type(self)):
+            return value.pack()
+
+        if value is None:
+            value = self._value
+
+        if value.find('/') >= 0:
+            value = value.split('/')[0]
+
+        try:
+            value = value.split(':')
+            return struct.pack('!8H', *[int(x, 16) for x in value])
+        except struct.error as err:
+            msg = "IPV6Address error. "
+            msg += "Class: {}, struct error: {} ".format(type(value).__name__,
+                                                         err)
+            raise exceptions.PackException(msg)
+    
+    def unpack(self, buff, offset=0):
+        """Unpack a binary message into this object's attributes.
+
+        Unpack the binary value *buff* and update this object attributes based
+        on the results.
+
+        Args:
+            buff (bytes): Binary data package to be unpacked.
+            offset (int): Where to begin unpacking.
+
+        Raises:
+            Exception: If there is a struct unpacking error.
+
+        """
+        def _int2hex(number):
+            return "{0:0{1}x}".format(number, 4)
+        
+        try:
+            unpacked_data = struct.unpack('!8H', buff[offset:offset+16])
+        except struct.error as exception:
+            raise exceptions.UnpackException('%s; %s: %s' % (exception,
+                                                             offset, buff))
+        
+        transformed_data = ':'.join([_int2hex(x) for x in unpacked_data])
+        self._value = transformed_data
+    
+    def get_size(self, value=None):
+        """Return the ipv6 address size in bytes.
+
+        Args:
+            value: In structs, the user can assign other value instead of
+                this class' instance. Here, in such cases, ``self`` is a class
+                attribute of the struct.
+
+        Returns:
+            int: The address size in bytes.
+
+        """
+        return 16
+    
+    def __deepcopy__(self, memo):
+        """Improve deepcopy speed."""
+        return IPV6Address(address=self._value, netmask=self.netmask)
 
 
 class HWAddress(GenericType):


### PR DESCRIPTION
Implement the IPv6 address class aiming to be used to implement the IPv6 source and IPv6 destination match fields as proposed in in of_core: https://github.com/kytos/of_core/issues/77