### PR TITLE
Add version-aware PortConfig and BadActionCode to utils

### DIFF
--- a/pyof/foundation/base.py
+++ b/pyof/foundation/base.py
@@ -424,7 +424,6 @@ class MetaStruct(type):
         an instance of the new version of the 'obj'.
 
         Example:
-
         >>> from pyof.foundation.base import MetaStruct as ms
         >>> from pyof.v0x01.common.header import Header
         >>> name = 'header'

--- a/pyof/foundation/exceptions.py
+++ b/pyof/foundation/exceptions.py
@@ -54,3 +54,10 @@ class UnpackException(Exception):
 
 class PackException(Exception):
     """Error while unpacking."""
+
+
+class UnsupportedVersionException(Exception):
+    """Exception raised when an unsupported OpenFlow version is specified."""
+
+    def __str__(self):
+        return "Version not supported: " + super().__str__()

--- a/pyof/utils.py
+++ b/pyof/utils.py
@@ -61,3 +61,21 @@ def unpack(packet):
         return message
     except (UnpackException, ValueError) as exception:
         raise UnpackException(exception)
+
+
+def is_ofbac_bad_out_port(code):
+    """Check if the code is a OFPBAC_BAD_OUT_PORT error."""
+    errors = (v0x01.asynchronous.error_msg.BadActionCode.OFPBAC_BAD_OUT_PORT,
+              v0x04.asynchronous.error_msg.BadActionCode.OFPBAC_BAD_OUT_PORT)
+    return code in errors
+
+
+def get_port_config_for_version(version):
+    """Return port_config object to a specific version of python-openflow."""
+    port_config = None
+
+    if version == 0x01:
+        port_config = v0x01.common.phy_port.PortConfig.OFPPC_NO_FWD
+    elif version == 0x04:
+        port_config = v0x04.common.port.PortConfig.OFPPC_NO_FWD
+    return port_config

--- a/pyof/utils.py
+++ b/pyof/utils.py
@@ -4,7 +4,8 @@ This package was moved from kytos/of_core for the purpose of creating a generic
 method to perform package unpack independent of the OpenFlow version.
 """
 from pyof import v0x01, v0x04
-from pyof.foundation.exceptions import UnpackException
+from pyof.foundation.exceptions import (
+    UnpackException, UnsupportedVersionException)
 from pyof.v0x01.common import utils as u_v0x01  # pylint: disable=unused-import
 from pyof.v0x04.common import utils as u_v0x04  # pylint: disable=unused-import
 
@@ -78,4 +79,7 @@ def get_port_config_for_version(version):
         port_config = v0x01.common.phy_port.PortConfig.OFPPC_NO_FWD
     elif version == 0x04:
         port_config = v0x04.common.port.PortConfig.OFPPC_NO_FWD
+    else:
+        raise UnsupportedVersionException(version)
+
     return port_config

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,10 @@
 """Automate utils tests."""
 import unittest
 
-from pyof.utils import UnpackException, unpack, validate_packet
+from pyof import v0x01, v0x04
+from pyof.utils import (is_ofbac_bad_out_port, get_port_config_for_version,
+                        UnpackException, unpack, UnsupportedVersionException,
+                        validate_packet)
 from pyof.v0x01.symmetric.hello import Hello as Hello_v0x01
 from pyof.v0x04.symmetric.hello import Hello as Hello_v0x04
 
@@ -37,3 +40,29 @@ class TestUtils(unittest.TestCase):
 
         hello.header.version = 0
         self.assertRaises(UnpackException, validate_packet, hello.pack())
+
+    def test_is_ofbac_bad_out_port_with_valid_code(self):
+        """Test is_ofbac_bad_out_port using a valid code."""
+        code = 4
+
+        self.assertEqual(is_ofbac_bad_out_port(code), True)
+
+    def test_is_ofbac_bad_out_port_with_invalid_code(self):
+        """Test is_ofbac_bad_out_port using a valid code."""
+        code = 0
+
+        self.assertEqual(is_ofbac_bad_out_port(code), False)
+
+    def test_success_get_port_config_for_version(self):
+        """Test get_port_config_for_version success cases."""
+        port_config_v0x01 = v0x01.common.phy_port.PortConfig.OFPPC_NO_FWD
+        port_config_v0x04 = v0x04.common.port.PortConfig.OFPPC_NO_FWD
+
+        self.assertEqual(get_port_config_for_version(0x01), port_config_v0x01)
+        self.assertEqual(get_port_config_for_version(0x04), port_config_v0x04)
+
+    def test_fail_get_port_config_for_version(self):
+        """Test get_port_config_for_version success cases."""
+
+        self.assertRaises(UnsupportedVersionException,
+                          get_port_config_for_version, 0x00)


### PR DESCRIPTION
The flow_manager NApp is importing resources from python-openflow with specific versions. This PR provides methods to make these resources available without adding version-specific imports. This makes it possible to have more versions of OpenFlow in the future without adding any import for them in flow_manager.