### PR TITLE
Remove python 3.6 references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 build: clean prepare
-	python3.6 setup.py sdist
+	python3 setup.py sdist
 	ls -l dist/
 
 clean:
 	rm -rf build/ dist/ *.egg-info/
 
 prepare:
-	pip3.6 install --upgrade pip setuptools wheel twine
+	pip3 install --upgrade pip setuptools wheel twine
 
 testupload: build
 	twine upload -r pypitest dist/*

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ Quick Start
 Installing
 ==========
 
-We use python3.6. So in order to use this software please install python3.6
-into your environment beforehand.
+In order to use this software please install python3.6 or greater into your 
+environment beforehand.
 
 We are doing a huge effort to make Kytos and its components available on all
 common distros. So, we recommend you to download it from your distro repository.
@@ -50,14 +50,14 @@ procedure:
 .. code-block:: shell
 
    $ cd python-openflow
-   $ sudo python3.6 setup.py install
+   $ sudo python3 setup.py install
 
 Alternatively, if you are a developer and want to install in develop mode:
 
 .. code-block:: shell
 
    $ cd python-openflow
-   $ pip3.6 install -r requirements/dev.txt
+   $ pip3 install -r requirements/dev.txt
 
 
 Basic Usage Example

--- a/setup.py
+++ b/setup.py
@@ -201,6 +201,8 @@ setup(name='python-openflow',
           'License :: OSI Approved :: MIT License',
           'Operating System :: POSIX :: Linux',
           'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
           'Topic :: System :: Networking',
           'Topic :: Software Development :: Libraries'
       ])

--- a/setup.py
+++ b/setup.py
@@ -203,6 +203,7 @@ setup(name='python-openflow',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
           'Topic :: System :: Networking',
           'Topic :: Software Development :: Libraries'
       ])


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Related: https://github.com/kytos/kytos/issues/1149


### :bookmark_tabs: Description of the Change

- Remove python 3.6 references
- Added references for python 3.7 and 3.8 in the setup.py file