### PR TITLE
Standardize `isenum` to `is_enum`

### DIFF
--- a/pyof/foundation/base.py
+++ b/pyof/foundation/base.py
@@ -137,7 +137,7 @@ class GenericType:
             object: The value of an enum, bitmask, etc.
 
         """
-        if self.isenum():
+        if self.is_enum():
             if isinstance(self._value, self.enum_ref):
                 return self._value.value
             return self._value
@@ -240,7 +240,7 @@ class GenericType:
         except BadValueException:
             return False
 
-    def isenum(self):
+    def is_enum(self):
         """Test whether it is an :class:`~enum.Enum`.
 
         Returns:


### PR DESCRIPTION
Current methods in the class are `is_valid`, `is_bitmask` and... `isenum`.

I've checked all the other projects and the method is only used inside the same file.