### PR TITLE
UBInt casting to int() + improved unit tests

### DIFF
--- a/pyof/foundation/base.py
+++ b/pyof/foundation/base.py
@@ -33,7 +33,7 @@ from pyof.foundation.exceptions import (
 
 # This will determine the order on sphinx documentation.
 __all__ = ('GenericStruct', 'GenericMessage', 'GenericType', 'GenericBitMask',
-           'MetaStruct', 'MetaBitMask')
+           'MetaStruct', 'MetaBitMask', 'UBIntBase')
 
 # Classes
 
@@ -41,7 +41,7 @@ __all__ = ('GenericStruct', 'GenericMessage', 'GenericType', 'GenericBitMask',
 class GenericType:
     """Foundation class for all custom attributes.
 
-    Base class for :class:`~.UBInt8`, :class:`~.Char`
+    Base class for :class:`~.UBIntBase`, :class:`~.Char`
     and others.
     """
 
@@ -257,6 +257,15 @@ class GenericType:
 
         """
         return self._value and issubclass(type(self._value), GenericBitMask)
+
+
+class UBIntBase(GenericType):
+    """Base class for UBInt{8,16,32,64,128}."""
+    def __int__(self):
+        """Allow converting an UBInt() back to an int()."""
+        # Skip GenericType's checking if this is an Enum ou BitMask
+        # (because it won't be), and convert directly from _value
+        return int(self._value)
 
 
 class MetaStruct(type):

--- a/pyof/foundation/base.py
+++ b/pyof/foundation/base.py
@@ -260,7 +260,7 @@ class GenericType:
 
 
 class MetaStruct(type):
-    """MetaClass that dinamically handles openflow version of class attributes.
+    """MetaClass that dynamically handles openflow version of class attributes.
 
     See more about it at:
         https://github.com/kytos/python-openflow/wiki/Version-Inheritance
@@ -424,7 +424,6 @@ class MetaStruct(type):
         an instance of the new version of the 'obj'.
 
         Example:
-
         >>> from pyof.foundation.base import MetaStruct as ms
         >>> from pyof.v0x01.common.header import Header
         >>> name = 'header'
@@ -503,7 +502,7 @@ class GenericStruct(metaclass=MetaStruct):
             other (GenericStruct): The struct to be compared with.
 
         Returns:
-            bool: Returns the result of comparation.
+            bool: Returns the comparison result.
 
         """
         return self.pack() == other.pack()
@@ -519,13 +518,13 @@ class GenericStruct(metaclass=MetaStruct):
 
     @staticmethod
     def _is_pyof_attribute(obj):
-        """Return True if the object is a kytos attribute.
+        """Return True if the object is a pyof attribute.
 
-        To be a kytos attribute the item must be an instance of either
+        To be a pyof attribute the item must be an instance of either
         GenericType or GenericStruct.
 
         Returns:
-            bool: Returns TRUE if the obj is a kytos attribute, otherwise False
+            bool: Returns True if the obj is a pyof attribute, otherwise False
 
         """
         return isinstance(obj, (GenericType, GenericStruct))

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -8,8 +8,6 @@ from copy import deepcopy
 from pyof.foundation import exceptions
 from pyof.foundation.base import GenericStruct, GenericType
 
-# Third-party imports
-
 __all__ = ('BinaryData', 'Char', 'ConstantTypeList', 'FixedTypeList',
            'IPAddress', 'DPID', 'HWAddress', 'Pad', 'UBInt8', 'UBInt16',
            'UBInt32', 'UBInt64')

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 # Local source tree imports
 from pyof.foundation import exceptions
-from pyof.foundation.base import GenericStruct, GenericType
+from pyof.foundation.base import GenericStruct, GenericType, UBIntBase
 
 __all__ = ('BinaryData', 'Char', 'ConstantTypeList', 'FixedTypeList',
            'IPAddress', 'DPID', 'HWAddress', 'Pad', 'UBInt8', 'UBInt16',
@@ -77,7 +77,7 @@ class Pad(GenericType):
         return Pad(length=self._length)
 
 
-class UBInt8(GenericType):
+class UBInt8(UBIntBase):
     """Format character for an Unsigned Char.
 
     Class for an 8-bit (1-byte) Unsigned Integer.
@@ -86,7 +86,7 @@ class UBInt8(GenericType):
     _fmt = "!B"
 
 
-class UBInt16(GenericType):
+class UBInt16(UBIntBase):
     """Format character for an Unsigned Short.
 
     Class for an 16-bit (2-byte) Unsigned Integer.
@@ -95,7 +95,7 @@ class UBInt16(GenericType):
     _fmt = "!H"
 
 
-class UBInt32(GenericType):
+class UBInt32(UBIntBase):
     """Format character for an Unsigned Int.
 
     Class for an 32-bit (4-byte) Unsigned Integer.
@@ -104,7 +104,7 @@ class UBInt32(GenericType):
     _fmt = "!I"
 
 
-class UBInt64(GenericType):
+class UBInt64(UBIntBase):
     """Format character for an Unsigned Long Long.
 
     Class for an 64-bit (8-byte) Unsigned Integer.
@@ -113,7 +113,7 @@ class UBInt64(GenericType):
     _fmt = "!Q"
 
 
-class UBInt128(GenericType):
+class UBInt128(UBIntBase):
     """Format character for an Unsigned Long Long.
 
     Class for an 128-bit (16-byte) Unsigned Integer.

--- a/pyof/foundation/basic_types.py
+++ b/pyof/foundation/basic_types.py
@@ -10,7 +10,7 @@ from pyof.foundation.base import GenericStruct, GenericType
 
 __all__ = ('BinaryData', 'Char', 'ConstantTypeList', 'FixedTypeList',
            'IPAddress', 'DPID', 'HWAddress', 'Pad', 'UBInt8', 'UBInt16',
-           'UBInt32', 'UBInt64')
+           'UBInt32', 'UBInt64', 'UBInt128')
 
 
 class Pad(GenericType):

--- a/pyof/foundation/network_types.py
+++ b/pyof/foundation/network_types.py
@@ -643,6 +643,7 @@ class IPv6(GenericStruct):
                  next_header=0, hop_limit=255, source="0:0:0:0:0:0:0:0",
                  destination="0:0:0:0:0:0:0:0", data=b''):
         """Create an IPv6 with the parameters below.
+
         Args:
             version (int): IP protocol version. Defaults to 6.
             tclass (int): DS (6 bits) + ECN (2 bits). Default is 0.

--- a/tests/unit/test_foundation/test_basic_types.py
+++ b/tests/unit/test_foundation/test_basic_types.py
@@ -57,6 +57,30 @@ class TestUBInt32(unittest.TestCase):
         self.assertEqual(self.ubint32.get_size(), 4)
 
 
+class TestUBInt64(unittest.TestCase):
+    """Test of UBInt64 BasicType."""
+
+    def setUp(self):
+        """Basic test setup."""
+        self.ubint64 = basic_types.UBInt64()
+
+    def test_get_size(self):
+        """[Foundation/BasicTypes/UBInt64] - size 8."""
+        self.assertEqual(self.ubint64.get_size(), 8)
+
+
+class TestUBInt128(unittest.TestCase):
+    """Test of UBInt128 BasicType."""
+
+    def setUp(self):
+        """Basic test setup."""
+        self.ubint128 = basic_types.UBInt128()
+
+    def test_get_size(self):
+        """[Foundation/BasicTypes/UBInt128] - size 16."""
+        self.assertEqual(self.ubint128.get_size(), 16)
+
+
 class TestChar(unittest.TestCase):
     """Test of Char BasicType."""
 

--- a/tests/unit/test_foundation/test_basic_types.py
+++ b/tests/unit/test_foundation/test_basic_types.py
@@ -2,6 +2,7 @@
 import unittest
 
 from pyof.foundation import basic_types
+from pyof.foundation.exceptions import PackException
 from pyof.foundation.basic_types import BinaryData
 
 
@@ -10,21 +11,26 @@ class TestUBInt8(unittest.TestCase):
 
     def setUp(self):
         """Basic test setup."""
-        self.ubint8 = basic_types.UBInt8()
+        self.ubint8 = basic_types.UBInt8(255)
 
     def test_get_size(self):
         """[Foundation/BasicTypes/UBInt8] - size 1."""
         self.assertEqual(self.ubint8.get_size(), 1)
 
-    @unittest.skip('Not yet implemented')
     def test_pack(self):
         """[Foundation/BasicTypes/UBInt8] - packing."""
-        pass
+        self.assertEqual(self.ubint8.pack(), b'\xff')
 
-    @unittest.skip('Not yet implemented')
     def test_unpack(self):
         """[Foundation/BasicTypes/UBInt8] - unpacking."""
-        pass
+        u = basic_types.UBInt8()
+        u.unpack(b'\xfe')
+        self.assertEqual(u.value, 254)
+
+    def test_pack_error(self):
+        """[Foundation/BasicTypes/UBInt8] - packing exception."""
+        u = basic_types.UBInt8(256)
+        self.assertRaises(PackException, u.pack)
 
 
 class TestUBInt16(unittest.TestCase):

--- a/tests/unit/test_foundation/test_basic_types.py
+++ b/tests/unit/test_foundation/test_basic_types.py
@@ -32,6 +32,9 @@ class TestUBInt8(unittest.TestCase):
         u = basic_types.UBInt8(256)
         self.assertRaises(PackException, u.pack)
 
+    def test_cast_to_int(self):
+        self.assertEqual(255, int(self.ubint8))
+
 
 class TestUBInt16(unittest.TestCase):
     """Test of UBInt16 BasicType."""

--- a/tests/unit/test_foundation/test_basic_types.py
+++ b/tests/unit/test_foundation/test_basic_types.py
@@ -44,16 +44,6 @@ class TestUBInt16(unittest.TestCase):
         """[Foundation/BasicTypes/UBInt16] - size 2."""
         self.assertEqual(self.ubint16.get_size(), 2)
 
-    @unittest.skip('Not yet implemented')
-    def test_pack(self):
-        """[Foundation/BasicTypes/UBInt16] - packing."""
-        pass
-
-    @unittest.skip('Not yet implemented')
-    def test_unpack(self):
-        """[Foundation/BasicTypes/UBInt16] - unpacking."""
-        pass
-
 
 class TestUBInt32(unittest.TestCase):
     """Test of UBInt32 BasicType."""
@@ -65,16 +55,6 @@ class TestUBInt32(unittest.TestCase):
     def test_get_size(self):
         """[Foundation/BasicTypes/UBInt32] - size 4."""
         self.assertEqual(self.ubint32.get_size(), 4)
-
-    @unittest.skip('Not yet implemented')
-    def test_pack(self):
-        """[Foundation/BasicTypes/UBInt32] - packing."""
-        pass
-
-    @unittest.skip('Not yet implemented')
-    def test_unpack(self):
-        """[Foundation/BasicTypes/UBInt32] - unpacking."""
-        pass
 
 
 class TestChar(unittest.TestCase):

--- a/tests/unit/test_foundation/test_basic_types.py
+++ b/tests/unit/test_foundation/test_basic_types.py
@@ -100,7 +100,7 @@ class TestChar(unittest.TestCase):
         self.assertEqual(char2.value, 'foo')
 
 
-class TestHWaddress(unittest.TestCase):
+class TestHWAddress(unittest.TestCase):
     """Test of HWAddress BasicType."""
 
     def test_unpack_packed(self):
@@ -199,5 +199,5 @@ class TestBinaryData(unittest.TestCase):
 
     def test_unexpected_value_as_parameter(self):
         """Should raise ValueError if pack value is not bytes."""
-        data= BinaryData('Some string')
-        self.assertRaises(ValueError, data.pack, "can't be string")
+        data = BinaryData('Some string')
+        self.assertRaises(ValueError, data.pack, "can't be a string")


### PR DESCRIPTION
The most controversial change is in 8b9240d4f90b759d01cdf987a9cca2351a487ed0. The rest are just improvements in the tests.

This is a basic first step that can make it easier to fix kytos/flow_manager#97 (UBInt serialization error).