### PR TITLE
SPHINXOPTS commented and sphinx build upgrade to 3.1.2

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W
+# SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -48,7 +48,7 @@ requests==2.23.0          # via sphinx
 six==1.14.0               # via astroid, livereload, packaging, pip-tools, tox, virtualenv
 snowballstemmer==2.0.0    # via sphinx
 sphinx-autobuild==0.7.1   # via kytos-sphinx-theme
-sphinx==2.0.1             # via kytos-sphinx-theme
+sphinx==3.1.2             # via kytos-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Working on #595 

### :bookmark_tabs: Description of the Change

By commenting the line 5 of docs Makefile `SPHINXOPTS = -W` you've got those warnings, that leads 
to remove the inheritance of `metaclass=MetaBitMask` from `GenericBitMask`, what reduces significantly 
the amount of warnings. Maybe this could mean that the problem is in the meta class `MetaBitMask`. 
Also changed sphinx version in  `dev.txt`.
