### PR TITLE
Default value for port_no in PortStatsRequest changed

### DIFF
--- a/pyof/v0x01/controller2switch/common.py
+++ b/pyof/v0x01/controller2switch/common.py
@@ -346,7 +346,7 @@ class PortStatsRequest(GenericStruct):
     #: Align to 64-bits.
     pad = Pad(6)
 
-    def __init__(self, port_no=None):
+    def __init__(self, port_no=Port.OFPP_NONE):
         """Create a PortStatsRequest with the optional parameters below.
 
         Args:


### PR DESCRIPTION
Fixes #630

### :bookmark_tabs: Description of the Change

The constructor of the class PortStatsRequest accepts a parameter named port_no.
Its default value was None, causing and error when the request was packed.
This PR changes the default value to Port.OFPP_NONE.

### :computer: Verification Process

All unit tests ran ok.

