### PR TITLE
Add __repr__ to `GroupMod` (+4 other classes)

### DIFF
--- a/pyof/foundation/base.py
+++ b/pyof/foundation/base.py
@@ -63,7 +63,7 @@ class GenericType:
         return type(self)(value=self._value, enum_ref=self.enum_ref)
 
     def __repr__(self):
-        return "{}({})".format(type(self).__name__, self._value)
+        return "{}({})".format(type(self).__name__, repr(self._value))
 
     def __str__(self):
         return '{}'.format(str(self._value))
@@ -516,6 +516,19 @@ class GenericStruct(metaclass=MetaStruct):
 
         """
         return self.pack() == other.pack()
+
+    # def __repr__(self):
+    #     """Generic fallback for __repr__ using the built-in introspection.
+    #
+    #     For debugging purposes. Disabled to avoid infinite recursion in
+    #     the case that objects reference each other.
+    #
+    #     """
+    #     # from pprint import pformat
+    #     # attributes = pformat(dict(self._get_instance_attributes()))
+    #     attributes = ', '.join(f'{k}={v!r}' for (k, v)
+    #                            in self._get_instance_attributes())
+    #     return f'{type(self).__name__}({attributes})'
 
     @staticmethod
     def _attr_fits_into_class(attr, cls):

--- a/pyof/v0x04/common/action.py
+++ b/pyof/v0x04/common/action.py
@@ -328,6 +328,9 @@ class ActionOutput(ActionHeader):
         self.port = port
         self.max_length = max_length
 
+    def __repr__(self):
+        return f"{type(self).__name__}(port={self.port})"
+
 
 class ActionPopMPLS(ActionHeader):
     """Action structure for OFPAT_POP_MPLS."""
@@ -387,6 +390,10 @@ class ActionSetField(ActionHeader):
         """
         super().__init__(action_type=ActionType.OFPAT_SET_FIELD)
         self.field = OxmTLV() if field is None else field
+
+    def __repr__(self):
+        return (f"{type(self).__name__}({self.field.oxm_field!s}, "
+                f"{self.field.oxm_value})")
 
     def pack(self, value=None):
         """Pack this structure updating the length and padding it."""

--- a/pyof/v0x04/common/header.py
+++ b/pyof/v0x04/common/header.py
@@ -102,3 +102,7 @@ class Header(GenericStruct):
         self.message_type = message_type
         self.length = length
         self.xid = xid
+
+    def __repr__(self):
+        return (f"{type(self).__name__}(version={self.version}, "
+                f"xid={self.xid}, {self.message_type!s})")

--- a/pyof/v0x04/controller2switch/common.py
+++ b/pyof/v0x04/controller2switch/common.py
@@ -224,6 +224,9 @@ class Bucket(GenericStruct):
         self.watch_group = watch_group
         self.actions = actions
 
+    def __repr__(self):
+        return f"{type(self).__name__}(actions={self.actions!r})"
+
     def unpack(self, buff, offset=0):
         """Unpack bucket.
 

--- a/pyof/v0x04/controller2switch/group_mod.py
+++ b/pyof/v0x04/controller2switch/group_mod.py
@@ -91,3 +91,8 @@ class GroupMod(GenericMessage):
         self.group_type = group_type
         self.group_id = group_id
         self.buckets = buckets
+
+    def __repr__(self):
+        return (f"{type(self).__name__}(xid={self.header.xid}, {self.command},"
+                f" group_type={self.group_type}, group_id={self.group_id},"
+                f" buckets={self.buckets!r})")


### PR DESCRIPTION
Fix #635.

Previous `repr()` examples:
```python
gm: GroupMod(xid=UBInt32(4))

gm.buckets[0]: <pyof.v0x04.controller2switch.common.Bucket object at 0x10f062d30>

gm.buckets[0].actions: [
 <pyof.v0x04.common.action.ActionSetField object at 0x10f069130>,
 <pyof.v0x04.common.action.ActionSetField object at 0x10f069490>,
 <pyof.v0x04.common.action.ActionOutput object at 0x10f069790>]

gm.header: <pyof.v0x04.common.header.Header object at 0x10f062be0>
```

With this PR:
```python
gm: GroupMod(xid=4, OFPGC_ADD, group_type=2, group_id=8,
  buckets=[
    Bucket(actions=[
        ActionSetField(OFPXMT_OFB_ETH_SRC, b'\x00\x00\x00\x11\x11T'), 
        ActionSetField(OFPXMT_OFB_ETH_DST, b'\x00\x00\x00""T'),
        ActionOutput(port=1)])])

gm.header: Header(version=4, xid=4, OFPT_GROUP_MOD)
```