### PR TITLE
Import setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,14 @@ descriptions.
 """
 import sys
 from abc import abstractmethod
-# Disabling checks due to https://github.com/PyCQA/pylint/issues/73
-# pylint: disable=import-error,no-name-in-module
-from distutils.command.clean import clean
 # pylint: enable=import-error,no-name-in-module
 from subprocess import CalledProcessError, call, check_call
 
 from setuptools import Command, find_packages, setup
+
+# Disabling checks due to https://github.com/PyCQA/pylint/issues/73
+# pylint: disable=import-error,no-name-in-module
+from distutils.command.clean import clean
 
 from pyof import __version__
 


### PR DESCRIPTION
setuptools 60 uses its own bundled version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This change in setuptools is to prepare for Python 3.12, which will drop distutils.

Fixes: https://bugs.debian.org/1022459